### PR TITLE
feat: FW-20 Push docker image on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**/*_test.go
+Makefile
+README.md
+.github

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,29 @@
+name: prepare release
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: "write"
+      contents: "write"
+      issues: "write"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install -g semantic-release
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: push docker image
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      packages: "write"
+      attestations: "write"
+      id-token: "write"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=release
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        id: push
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,3 +16,12 @@ jobs:
           cache-dependency-path: "**/go.sum"
       - name: Run the tests
         run: make run-tests
+
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build image
+        run: make build-image

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["@semantic-release/github"]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+ARG GO_VERSION="1.22.7-bookworm"
+FROM golang:${GO_VERSION}
+
+ARG PORT=8080
+ARG USERNAME=server
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+USER $USERNAME
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+COPY cmd ./cmd
+COPY internal ./internal
+
+EXPOSE $PORT
+
+CMD ["go", "run", "/app/cmd/main.go"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 ROOT ?= ./
+IMAGE_NAME ?= "festwrap-server"
+IMAGE_TAG ?= "latest"
 
 .PHONY: pre-commit-install
 pre-commit-install:
@@ -8,3 +10,7 @@ pre-commit-install:
 .PHONY: run-tests
 run-tests:
 	go test $(ROOT)/...
+
+.PHONE: build-image
+build-image:
+	docker build -f Dockerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .

--- a/cmd/handler/artists.go
+++ b/cmd/handler/artists.go
@@ -54,8 +54,6 @@ func (h *SearchArtistHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		h.writeUnexpectedError(w)
 		return
 	}
-
-	w.WriteHeader(http.StatusOK)
 }
 
 func (h *SearchArtistHandler) readLimit(r *http.Request) (int, error) {


### PR DESCRIPTION
# Description

These changes introduce a couple of new workflows:
- A workflow to generate a release on each merge to main.
- A workflow to push a Docker image into the Github repository on release.

Therefore, every time we merge into main, a new release and Docker image will be generated.

Also testing the Docker image can be built on each PR and merge to main.