### PR TITLE
ci: FW-20 Fix release & push CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,5 +25,5 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
         run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=release
+            type=semver,pattern={{version}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
# Description

Github prevents a workflow from triggering another workflow, as described here: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflows

Therefore, we decide to use a Github token in order to perfrom the release, so the release workflow can then trigger the workflow triggering the Docker push.

We did not include all the steps in a single job since it was not straightforward to get the semantic release value in a consistent way.

We are also fixing the tag for the docker push.