### PR TITLE
chore(ci): do not use personal token in flow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,5 +24,5 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
# Description

Github workflows that use the provided GITHUB_TOKEN cannot trigger other workflows. However, workflows that run on `workflow_dispatch` are an exception to that. Therefore, we can stop using our own Personal Token here and resort to using the one provided by Github, which is more secure and maintainable.

See the [docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow).
