### PR TITLE
feat: FW-43 Add logging to handler

### DIFF
--- a/cmd/handler/artists_test.go
+++ b/cmd/handler/artists_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"festwrap/internal/artist"
+	"festwrap/internal/logging"
 	"festwrap/internal/serialization"
 	"festwrap/internal/testtools"
 )
@@ -47,7 +48,7 @@ func buildRequestWithParams(t *testing.T, params map[string]string) *http.Reques
 func createSearchArtistHandler() SearchArtistHandler {
 	repository := artist.FakeArtistRepository{}
 	repository.SetSearchReturnValue(defaultArtists())
-	return NewSearchArtistHandler(&repository)
+	return NewSearchArtistHandler(&repository, logging.NoopLogger{})
 }
 
 func unmarshalSearchArtistResponse(t *testing.T, bytes []byte) []artist.Artist {
@@ -124,7 +125,7 @@ func TestLimitStatusCodeDependingOnValue(t *testing.T) {
 func TestSearchArtistRepositoryCalledWithParams(t *testing.T) {
 	repository := artist.FakeArtistRepository{}
 	repository.SetSearchReturnValue(defaultArtists())
-	handler := NewSearchArtistHandler(&repository)
+	handler := NewSearchArtistHandler(&repository, logging.NoopLogger{})
 	request := buildRequestWithParams(t, defaultQueryParams())
 
 	handler.ServeHTTP(httptest.NewRecorder(), request)

--- a/internal/logging/base.go
+++ b/internal/logging/base.go
@@ -1,0 +1,23 @@
+package logging
+
+import "log/slog"
+
+type BaseLogger struct {
+	logger *slog.Logger
+}
+
+func (l BaseLogger) Info(message string) {
+	l.logger.Info(message)
+}
+
+func (l BaseLogger) Warn(message string) {
+	l.logger.Warn(message)
+}
+
+func (l BaseLogger) Error(message string) {
+	l.logger.Error(message)
+}
+
+func NewBaseLogger(logger *slog.Logger) BaseLogger {
+	return BaseLogger{logger: logger}
+}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,7 @@
+package logging
+
+type Logger interface {
+	Info(message string)
+	Warn(message string)
+	Error(message string)
+}

--- a/internal/logging/noop.go
+++ b/internal/logging/noop.go
@@ -1,0 +1,9 @@
+package logging
+
+type NoopLogger struct{}
+
+func (l NoopLogger) Info(message string) {}
+
+func (l NoopLogger) Warn(message string) {}
+
+func (l NoopLogger) Error(message string) {}


### PR DESCRIPTION
# Description

Add logging module and use logging in artists handler.

# Test

Start the app:

```shell
go run cmd/main.go
```

Then query the endpoint (need to generate an access token, see [here](https://github.com/DanielMoraDC/festwrap-ui)):

```shell
curl --location 'http://localhost:8080/artists/search?name=Brutus' \
      --header 'Authorization: <token>'
```

We get:

```json
{"time":"2024-11-06T09:11:24.158418+01:00","level":"INFO","msg":"Received new request for Brutus, using limit 5"}
{"time":"2024-11-06T09:11:24.334223+01:00","level":"INFO","msg":"Found artist [{Brutus https://i.scdn.co/image/ab6761610000f17883678eabacd66cedd7063cf7} {Brutus' Daughters https://i.scdn.co/image/ab6761610000f178f0143378468e166f4274e1fc} {Big Brutus https://i.scdn.co/image/ab6761610000f178600cb5fcc42a845413920957} {Brutus Backlash } {Brutus https://i.scdn.co/image/ab67616d000048519811aaaac98c93980aa8a2b8}] for Brutus, using limit 5"}
```

