### PR TITLE
feat: FW-6 iImplement playlist search in repository

### DIFF
--- a/internal/artist/spotify/spotify_artist_repository_test.go
+++ b/internal/artist/spotify/spotify_artist_repository_test.go
@@ -111,8 +111,7 @@ func defaultSender() *httpsender.FakeHTTPSender {
 
 func defaultDeserializer() *serialization.FakeDeserializer[spotifyResponse] {
 	deserializer := &serialization.FakeDeserializer[spotifyResponse]{}
-	response := defaultDeserializedResponse()
-	deserializer.SetResponse(&response)
+	deserializer.SetResponse(defaultDeserializedResponse())
 	return deserializer
 }
 
@@ -187,7 +186,7 @@ func TestSearchArtistReturnsEmptyIfNoneFound(t *testing.T) {
 	repository := spotifySongRepository(defaultSender())
 	deserializer := defaultDeserializer()
 	emptyResponse := spotifyResponse{Artists: spotifyArtists{ArtistItems: []spotifyArtist{}}}
-	deserializer.SetResponse(&emptyResponse)
+	deserializer.SetResponse(emptyResponse)
 	repository.SetDeserializer(deserializer)
 
 	artists, _ := repository.SearchArtist(defaultContext(), defaultSearchName(), defaultLimit())

--- a/internal/playlist/concurrent_playlist_service.go
+++ b/internal/playlist/concurrent_playlist_service.go
@@ -1,6 +1,7 @@
 package playlist
 
 import (
+	"context"
 	"festwrap/internal/playlist/errors"
 	"festwrap/internal/setlist"
 	"festwrap/internal/song"
@@ -32,7 +33,7 @@ func NewConcurrentPlaylistService(
 	}
 }
 
-func (s *ConcurrentPlaylistService) AddSetlist(playlistId string, artist string) error {
+func (s *ConcurrentPlaylistService) AddSetlist(ctx context.Context, playlistId string, artist string) error {
 	setlist, err := s.setlistRepository.GetSetlist(artist, s.minSongs)
 	if err != nil {
 		return err
@@ -56,7 +57,7 @@ func (s *ConcurrentPlaylistService) AddSetlist(playlistId string, artist string)
 		return errors.NewCannotAddSongsToPlaylistError(message)
 	}
 
-	err = s.playlistRepository.AddSongs(playlistId, songs)
+	err = s.playlistRepository.AddSongs(ctx, playlistId, songs)
 	if err != nil {
 		return err
 	}

--- a/internal/playlist/errors/cannot_search_playlist.go
+++ b/internal/playlist/errors/cannot_search_playlist.go
@@ -1,0 +1,13 @@
+package errors
+
+type CannotSearchPlaylistError struct {
+	message string
+}
+
+func NewCannotSearchPlaylistError(message string) error {
+	return &CannotSearchPlaylistError{message: message}
+}
+
+func (e *CannotSearchPlaylistError) Error() string {
+	return e.message
+}

--- a/internal/playlist/fake_playlist_repository.go
+++ b/internal/playlist/fake_playlist_repository.go
@@ -17,19 +17,34 @@ type CreatePlaylistArgs struct {
 	Playlist Playlist
 }
 
+type SearchPlaylistArgs struct {
+	Context      context.Context
+	PlaylistName string
+	Limit        int
+}
+
 type FakePlaylistRepository struct {
 	addSongArgs        AddSongsArgs
 	createPlaylistArgs CreatePlaylistArgs
+	searchPlaylistArgs SearchPlaylistArgs
+	searchedPlaylists  []Playlist
 	err                error
 }
 
 func NewFakePlaylistRepository() FakePlaylistRepository {
-	return FakePlaylistRepository{}
+	return FakePlaylistRepository{searchedPlaylists: []Playlist{}}
 }
 
 func (s *FakePlaylistRepository) CreatePlaylist(ctx context.Context, userId string, playlist Playlist) error {
 	s.createPlaylistArgs = CreatePlaylistArgs{Context: ctx, UserId: userId, Playlist: playlist}
 	return s.err
+}
+
+func (s *FakePlaylistRepository) SearchPlaylist(
+	ctx context.Context, playlistName string, limit int,
+) ([]Playlist, error) {
+	s.searchPlaylistArgs = SearchPlaylistArgs{Context: ctx, PlaylistName: playlistName, Limit: limit}
+	return s.searchedPlaylists, s.err
 }
 
 func (s *FakePlaylistRepository) AddSongs(ctx context.Context, playlistId string, songs []song.Song) error {
@@ -47,4 +62,12 @@ func (s *FakePlaylistRepository) GetAddSongArgs() AddSongsArgs {
 
 func (s *FakePlaylistRepository) GetCreatePlaylistSongArgs() CreatePlaylistArgs {
 	return s.createPlaylistArgs
+}
+
+func (s *FakePlaylistRepository) GetSearchPlaylistArgs() SearchPlaylistArgs {
+	return s.searchPlaylistArgs
+}
+
+func (s *FakePlaylistRepository) SetSearchedPlaylists(playlists []Playlist) {
+	s.searchedPlaylists = playlists
 }

--- a/internal/playlist/fake_playlist_repository.go
+++ b/internal/playlist/fake_playlist_repository.go
@@ -1,13 +1,18 @@
 package playlist
 
-import "festwrap/internal/song"
+import (
+	"context"
+	"festwrap/internal/song"
+)
 
 type AddSongsArgs struct {
+	Context    context.Context
 	PlaylistId string
 	Songs      []song.Song
 }
 
 type CreatePlaylistArgs struct {
+	Context  context.Context
 	UserId   string
 	Playlist Playlist
 }
@@ -22,13 +27,13 @@ func NewFakePlaylistRepository() FakePlaylistRepository {
 	return FakePlaylistRepository{}
 }
 
-func (s *FakePlaylistRepository) CreatePlaylist(userId string, playlist Playlist) error {
-	s.createPlaylistArgs = CreatePlaylistArgs{UserId: userId, Playlist: playlist}
+func (s *FakePlaylistRepository) CreatePlaylist(ctx context.Context, userId string, playlist Playlist) error {
+	s.createPlaylistArgs = CreatePlaylistArgs{Context: ctx, UserId: userId, Playlist: playlist}
 	return s.err
 }
 
-func (s *FakePlaylistRepository) AddSongs(playlistId string, songs []song.Song) error {
-	s.addSongArgs = AddSongsArgs{PlaylistId: playlistId, Songs: songs}
+func (s *FakePlaylistRepository) AddSongs(ctx context.Context, playlistId string, songs []song.Song) error {
+	s.addSongArgs = AddSongsArgs{Context: ctx, PlaylistId: playlistId, Songs: songs}
 	return s.err
 }
 

--- a/internal/playlist/playlist_repository.go
+++ b/internal/playlist/playlist_repository.go
@@ -1,8 +1,11 @@
 package playlist
 
-import "festwrap/internal/song"
+import (
+	"context"
+	"festwrap/internal/song"
+)
 
 type PlaylistRepository interface {
-	CreatePlaylist(userId string, playlist Playlist) error
-	AddSongs(playlistId string, songs []song.Song) error
+	CreatePlaylist(ctx context.Context, userId string, playlist Playlist) error
+	AddSongs(ctx context.Context, playlistId string, songs []song.Song) error
 }

--- a/internal/playlist/playlist_repository.go
+++ b/internal/playlist/playlist_repository.go
@@ -7,5 +7,6 @@ import (
 
 type PlaylistRepository interface {
 	CreatePlaylist(ctx context.Context, userId string, playlist Playlist) error
+	SearchPlaylist(ctx context.Context, name string, limit int) ([]Playlist, error)
 	AddSongs(ctx context.Context, playlistId string, songs []song.Song) error
 }

--- a/internal/playlist/playlist_service.go
+++ b/internal/playlist/playlist_service.go
@@ -1,5 +1,7 @@
 package playlist
 
+import "context"
+
 type PlaylistService interface {
-	AddSetlist(playlistId string, artist string)
+	AddSetlist(ctx context.Context, playlistId string, artist string) error
 }

--- a/internal/playlist/spotify/spotify_get_playlist_response.go
+++ b/internal/playlist/spotify/spotify_get_playlist_response.go
@@ -1,0 +1,20 @@
+package spotify
+
+type SpotifyPlaylistOwnerMetadata struct {
+	Id string `json:"id"`
+}
+
+type SpotifySearchPlaylist struct {
+	Description   string                       `json:"description"`
+	Name          string                       `json:"name"`
+	Public        bool                         `json:"public"`
+	OwnerMetadata SpotifyPlaylistOwnerMetadata `json:"owner"`
+}
+
+type SpotifySearchPlaylists struct {
+	Items []SpotifySearchPlaylist `json:"items"`
+}
+
+type SpotifySearchPlaylistResponse struct {
+	Playlists SpotifySearchPlaylists `json:"playlists"`
+}

--- a/internal/playlist/spotify/spotify_playlist_repository.go
+++ b/internal/playlist/spotify/spotify_playlist_repository.go
@@ -140,12 +140,24 @@ func (r *SpotifyPlaylistRepository) SetTokenKey(key types.ContextKey) {
 	r.tokenKey = key
 }
 
+func (r *SpotifyPlaylistRepository) GetHTTPSender() httpsender.HTTPRequestSender {
+	return r.httpSender
+}
+
 func (r *SpotifyPlaylistRepository) SetHTTPSender(httpSender httpsender.HTTPRequestSender) {
 	r.httpSender = httpSender
 }
 
 func (r *SpotifyPlaylistRepository) SetSongSerializer(serializer serialization.Serializer[SpotifySongs]) {
 	r.songsSerializer = serializer
+}
+
+func (r *SpotifyPlaylistRepository) GetSongSerializer() serialization.Serializer[SpotifySongs] {
+	return r.songsSerializer
+}
+
+func (r *SpotifyPlaylistRepository) GetPlaylistSerializer() serialization.Serializer[SpotifyPlaylist] {
+	return r.playlistSerializer
 }
 
 func (r *SpotifyPlaylistRepository) SetPlaylistSerializer(serializer serialization.Serializer[SpotifyPlaylist]) {

--- a/internal/playlist/spotify/spotify_playlist_repository_test.go
+++ b/internal/playlist/spotify/spotify_playlist_repository_test.go
@@ -115,22 +115,10 @@ func defaultSongsSerializer() *serialization.FakeSerializer[SpotifySongs] {
 	return &serializer
 }
 
-func errorSongsSerializer() *serialization.FakeSerializer[SpotifySongs] {
-	serializer := defaultSongsSerializer()
-	serializer.SetError(errors.New("test songs error"))
-	return serializer
-}
-
 func defaultPlaylistSerializer() *serialization.FakeSerializer[SpotifyPlaylist] {
 	serializer := serialization.FakeSerializer[SpotifyPlaylist]{}
 	serializer.SetResponse(defaultPlaylistBody())
 	return &serializer
-}
-
-func errorPlaylistSerializer() *serialization.FakeSerializer[SpotifyPlaylist] {
-	serializer := defaultPlaylistSerializer()
-	serializer.SetError(errors.New("test playlist error"))
-	return serializer
 }
 
 func defaultPlaylistDeserializer() *serialization.FakeDeserializer[SpotifySearchPlaylistResponse] {
@@ -228,7 +216,9 @@ func TestAddSongsSerializesInputSongs(t *testing.T) {
 
 func TestAddSongsReturnsErrorOnNonSerializationError(t *testing.T) {
 	repository := spotifyPlaylistRepository()
-	repository.SetSongSerializer(errorSongsSerializer())
+	serializer := defaultSongsSerializer()
+	serializer.SetError(errors.New("test songs error"))
+	repository.SetSongSerializer(serializer)
 
 	err := repository.AddSongs(defaultContext(), defaultPlaylistId(), defaultSongs())
 
@@ -265,7 +255,9 @@ func TestAddSongsSerializesInputPlaylist(t *testing.T) {
 
 func TestCreatePlaylistReturnsErrorOnPlaylistSerializationError(t *testing.T) {
 	repository := spotifyPlaylistRepository()
-	repository.SetPlaylistSerializer(errorPlaylistSerializer())
+	serializer := defaultPlaylistSerializer()
+	serializer.SetError(errors.New("test playlist error"))
+	repository.SetPlaylistSerializer(serializer)
 
 	err := repository.CreatePlaylist(defaultContext(), defaultUserId(), defaultPlaylist())
 

--- a/internal/playlist/spotify/spotify_playlist_repository_test.go
+++ b/internal/playlist/spotify/spotify_playlist_repository_test.go
@@ -218,13 +218,11 @@ func TestAddSongsReturnsErrorWhenNoSongsProvided(t *testing.T) {
 
 func TestAddSongsSerializesInputSongs(t *testing.T) {
 	repository := spotifyPlaylistRepository()
-	serializer := defaultSongsSerializer()
-	repository.SetSongSerializer(serializer)
 
 	repository.AddSongs(defaultContext(), defaultPlaylistId(), defaultSongs())
 
 	expected := SpotifySongs{Uris: []string{"uri1", "uri2"}}
-	actual := serializer.GetArgs()
+	actual := repository.GetSongSerializer().(*serialization.FakeSerializer[SpotifySongs]).GetArgs()
 	testtools.AssertEqual(t, actual, expected)
 }
 
@@ -238,20 +236,17 @@ func TestAddSongsReturnsErrorOnNonSerializationError(t *testing.T) {
 }
 
 func TestAddSongsSendsRequestUsingProperOptions(t *testing.T) {
-	sender := fakeSender()
 	repository := spotifyPlaylistRepository()
-	repository.SetHTTPSender(sender)
 
 	repository.AddSongs(defaultContext(), defaultPlaylistId(), defaultSongs())
 
-	actual := sender.GetSendArgs()
+	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
 	testtools.AssertEqual(t, actual, expectedAddSongsHttpOptions())
 }
 
 func TestAddSongsReturnsErrorOnSendError(t *testing.T) {
-	sender := errorSender()
 	repository := spotifyPlaylistRepository()
-	repository.SetHTTPSender(sender)
+	repository.SetHTTPSender(errorSender())
 
 	err := repository.AddSongs(defaultContext(), defaultPlaylistId(), defaultSongs())
 
@@ -260,13 +255,11 @@ func TestAddSongsReturnsErrorOnSendError(t *testing.T) {
 
 func TestAddSongsSerializesInputPlaylist(t *testing.T) {
 	repository := spotifyPlaylistRepository()
-	serializer := defaultPlaylistSerializer()
-	repository.SetPlaylistSerializer(serializer)
 
 	repository.CreatePlaylist(defaultContext(), defaultUserId(), defaultPlaylist())
 
 	expected := SpotifyPlaylist{Name: "my-playlist", Description: "some playlist", IsPublic: false}
-	actual := serializer.GetArgs()
+	actual := repository.GetPlaylistSerializer().(*serialization.FakeSerializer[SpotifyPlaylist]).GetArgs()
 	testtools.AssertEqual(t, actual, expected)
 }
 
@@ -280,20 +273,17 @@ func TestCreatePlaylistReturnsErrorOnPlaylistSerializationError(t *testing.T) {
 }
 
 func TestCreatePlaylistSendsCreateRequestWithOptions(t *testing.T) {
-	sender := fakeSender()
 	repository := spotifyPlaylistRepository()
-	repository.SetHTTPSender(sender)
 
 	repository.CreatePlaylist(defaultContext(), defaultUserId(), defaultPlaylist())
 
-	actual := sender.GetSendArgs()
+	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
 	testtools.AssertEqual(t, actual, expectedCreatePlaylistHttpOptions())
 }
 
 func TestCreatePlaylistReturnsErrorOnSendError(t *testing.T) {
-	sender := errorSender()
 	repository := spotifyPlaylistRepository()
-	repository.SetHTTPSender(sender)
+	repository.SetHTTPSender(errorSender())
 
 	err := repository.CreatePlaylist(defaultContext(), defaultUserId(), defaultPlaylist())
 
@@ -301,20 +291,17 @@ func TestCreatePlaylistReturnsErrorOnSendError(t *testing.T) {
 }
 
 func TestSearchPlaylistSendsCreateRequestWithOptions(t *testing.T) {
-	sender := fakeSender()
 	repository := spotifyPlaylistRepository()
-	repository.SetHTTPSender(sender)
 
 	repository.SearchPlaylist(defaultContext(), defaultPlaylistName(), defaultSearchPlaylistLimit())
 
-	actual := sender.GetSendArgs()
+	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
 	testtools.AssertEqual(t, actual, expectedSearchPlaylistHttpOptions())
 }
 
 func TestSearchPlaylistReturnsErrorOnSendError(t *testing.T) {
-	sender := errorSender()
 	repository := spotifyPlaylistRepository()
-	repository.SetHTTPSender(sender)
+	repository.SetHTTPSender(errorSender())
 
 	_, err := repository.SearchPlaylist(defaultContext(), defaultPlaylistName(), defaultSearchPlaylistLimit())
 
@@ -344,30 +331,26 @@ func TestSearchPlaylistReturnsDeserializedContent(t *testing.T) {
 func TestAddSongsPlaylistSendsOptionsUsingSerializerIntegration(t *testing.T) {
 	testtools.SkipOnShortRun(t)
 
-	sender := fakeSender()
 	serializer := serialization.NewJsonSerializer[SpotifySongs]()
 	repository := spotifyPlaylistRepository()
-	repository.SetHTTPSender(sender)
 	repository.SetSongSerializer(&serializer)
 
 	repository.AddSongs(defaultContext(), defaultPlaylistId(), defaultSongs())
 
-	actual := sender.GetSendArgs()
+	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
 	testtools.AssertEqual(t, actual, expectedAddSongsHttpOptions())
 }
 
 func TestCreatePlaylistSendsOptionsUsingSerializerIntegration(t *testing.T) {
 	testtools.SkipOnShortRun(t)
 
-	sender := fakeSender()
 	serializer := serialization.NewJsonSerializer[SpotifyPlaylist]()
 	repository := spotifyPlaylistRepository()
 	repository.SetPlaylistSerializer(&serializer)
-	repository.SetHTTPSender(sender)
 
 	repository.CreatePlaylist(defaultContext(), defaultUserId(), defaultPlaylist())
 
-	actual := sender.GetSendArgs()
+	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
 	testtools.AssertEqual(t, actual, expectedCreatePlaylistHttpOptions())
 }
 

--- a/internal/serialization/fake_deserializer.go
+++ b/internal/serialization/fake_deserializer.go
@@ -2,7 +2,7 @@ package serialization
 
 type FakeDeserializer[T any] struct {
 	bytes  []byte
-	result *T
+	result T
 	err    error
 }
 
@@ -10,7 +10,7 @@ func (d *FakeDeserializer[T]) GetArgs() []byte {
 	return d.bytes
 }
 
-func (d *FakeDeserializer[T]) SetResponse(result *T) {
+func (d *FakeDeserializer[T]) SetResponse(result T) {
 	d.result = result
 }
 
@@ -20,7 +20,7 @@ func (d *FakeDeserializer[T]) SetError(err error) {
 
 func (d *FakeDeserializer[T]) Deserialize(bytes []byte, dest *T) error {
 	d.bytes = bytes
-	*dest = *d.result
+	*dest = d.result
 	if d.err != nil {
 		return d.err
 	}

--- a/internal/setlist/setlistfm/setlistfm_setlist_repository_test.go
+++ b/internal/setlist/setlistfm/setlistfm_setlist_repository_test.go
@@ -47,8 +47,7 @@ func defaultSender() *httpsender.FakeHTTPSender {
 
 func defaultDeserializer() serialization.FakeDeserializer[setlistFMResponse] {
 	result := serialization.FakeDeserializer[setlistFMResponse]{}
-	response := deserializedResponse()
-	result.SetResponse(&response)
+	result.SetResponse(deserializedResponse())
 	return result
 }
 
@@ -149,7 +148,7 @@ func TestGetSetlistReturnsErrorOnDeserializationError(t *testing.T) {
 func TestGetSetlistReturnsErrorIfNoSetlistFound(t *testing.T) {
 	repository := setlistRepository(defaultSender())
 	deserializer := defaultDeserializer()
-	emptyResponse := &setlistFMResponse{Body: []setlistFMSetlist{}}
+	emptyResponse := setlistFMResponse{Body: []setlistFMSetlist{}}
 	deserializer.SetResponse(emptyResponse)
 	repository.SetDeserializer(&deserializer)
 

--- a/internal/song/spotify/spotify_song_repository_test.go
+++ b/internal/song/spotify/spotify_song_repository_test.go
@@ -58,8 +58,7 @@ func defaultSender() *httpsender.FakeHTTPSender {
 
 func defaultDeserializer() *serialization.FakeDeserializer[spotifyResponse] {
 	deserializer := &serialization.FakeDeserializer[spotifyResponse]{}
-	response := defaultDeserializedResponse()
-	deserializer.SetResponse(&response)
+	deserializer.SetResponse(defaultDeserializedResponse())
 	return deserializer
 }
 
@@ -115,7 +114,7 @@ func TestGetSongReturnsErrorIfNoSongsFound(t *testing.T) {
 	repository := spotifySongRepository(defaultSender())
 	deserializer := defaultDeserializer()
 	emptyResponse := spotifyResponse{Tracks: spotifyTracks{Songs: []spotifySong{}}}
-	deserializer.SetResponse(&emptyResponse)
+	deserializer.SetResponse(emptyResponse)
 	repository.SetDeserializer(deserializer)
 
 	_, err := repository.GetSong(defaultArtist(), defaultTitle())


### PR DESCRIPTION
# Description

Adds search playlist method in interface and creates an implementation for the Spotify repository. We are only retrieving the playlists actually owned by the user, as Spotify search returns all possible matches. User playlists, though, are always placed first.

In order to use the user id and the token inside the repository, we use the Golang context as already done in other repositories.

We also take the chance to do some scouting and reduce test boilerplate code.