### PR TITLE
feat: FW-6 Implement playlist search endpoint

### DIFF
--- a/cmd/middleware/auth_token_test.go
+++ b/cmd/middleware/auth_token_test.go
@@ -23,7 +23,7 @@ func defaultTokenKey() types.ContextKey {
 	return tokenKey
 }
 
-func testSetup() (AuthTokenMiddleware, *http.Request, *httptest.ResponseRecorder) {
+func tokenAuthMiddlewareTestSetup() (AuthTokenMiddleware, *http.Request, *httptest.ResponseRecorder) {
 	middleware := NewAuthTokenMiddleware(GetTokenHandler{})
 	request := httptest.NewRequest("GET", "http://example.com", nil)
 	writer := httptest.NewRecorder()
@@ -31,7 +31,7 @@ func testSetup() (AuthTokenMiddleware, *http.Request, *httptest.ResponseRecorder
 }
 
 func TestBadRequestErrorOnMissingAuthHeader(t *testing.T) {
-	middleware, request, writer := testSetup()
+	middleware, request, writer := tokenAuthMiddlewareTestSetup()
 
 	middleware.ServeHTTP(writer, request)
 
@@ -39,7 +39,7 @@ func TestBadRequestErrorOnMissingAuthHeader(t *testing.T) {
 }
 
 func TestUnprocessableEntityErrorOnWronglyFormattedAuthHeader(t *testing.T) {
-	middleware, request, writer := testSetup()
+	middleware, request, writer := tokenAuthMiddlewareTestSetup()
 	request.Header.Set("Authorization", "something")
 
 	middleware.ServeHTTP(writer, request)
@@ -48,7 +48,7 @@ func TestUnprocessableEntityErrorOnWronglyFormattedAuthHeader(t *testing.T) {
 }
 
 func TestTokenIsPlacedInExpectedContextKey(t *testing.T) {
-	middleware, request, writer := testSetup()
+	middleware, request, writer := tokenAuthMiddlewareTestSetup()
 	request.Header.Set("Authorization", "Bearer 1234")
 
 	middleware.ServeHTTP(writer, request)
@@ -57,7 +57,7 @@ func TestTokenIsPlacedInExpectedContextKey(t *testing.T) {
 }
 
 func TestMiddlewareReturnsStatusCodeofTheHandler(t *testing.T) {
-	middleware, request, writer := testSetup()
+	middleware, request, writer := tokenAuthMiddlewareTestSetup()
 	request.Header.Set("Authorization", "Bearer 1234")
 
 	middleware.ServeHTTP(writer, request)

--- a/cmd/middleware/user_id.go
+++ b/cmd/middleware/user_id.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"context"
+	types "festwrap/internal"
+	"net/http"
+
+	"festwrap/internal/user"
+)
+
+type UserIdMiddleware struct {
+	userIdKey      types.ContextKey
+	userRepository user.UserRepository
+	handler        http.Handler
+}
+
+// Adds the current user identifier into the context by using the provided user repository
+func NewUserIdMiddleware(handler http.Handler, userRepository user.UserRepository) UserIdMiddleware {
+	return UserIdMiddleware{userIdKey: types.ContextKey("user_id"), userRepository: userRepository, handler: handler}
+}
+
+func (m UserIdMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	currentUserId, err := m.userRepository.GetCurrentUserId(r.Context())
+	if err != nil {
+		http.Error(w, "Unexpected error: could not retrieve user id", http.StatusInternalServerError)
+	}
+
+	ctxWithUserId := context.WithValue(r.Context(), m.userIdKey, currentUserId)
+	requestWithUserId := r.WithContext(ctxWithUserId)
+	m.handler.ServeHTTP(w, requestWithUserId)
+}
+
+func (m *UserIdMiddleware) SetUserIdKey(key types.ContextKey) {
+	m.userIdKey = key
+}
+
+func (m UserIdMiddleware) GetUserRepository() user.UserRepository {
+	return m.userRepository
+}
+
+func (m *UserIdMiddleware) SetUserRepository(repository user.UserRepository) {
+	m.userRepository = repository
+}

--- a/cmd/middleware/user_id_test.go
+++ b/cmd/middleware/user_id_test.go
@@ -1,0 +1,79 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	types "festwrap/internal"
+	"festwrap/internal/testtools"
+	"festwrap/internal/user"
+)
+
+type GetUserIdHandler struct{}
+
+func (h GetUserIdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	userId, _ := r.Context().Value(defaultUserIdKey()).(string)
+	w.WriteHeader(http.StatusContinue)
+	fmt.Fprint(w, userId)
+}
+
+func defaultUserIdKey() types.ContextKey {
+	var userIdKey types.ContextKey = "user_key"
+	return userIdKey
+}
+
+func defaultContext() context.Context {
+	ctx := context.Background()
+	context.WithValue(ctx, "some key", "some value")
+	return ctx
+}
+
+func userIdMiddlewareTestSetup() (UserIdMiddleware, *http.Request, *httptest.ResponseRecorder) {
+	userRepository := user.FakeUserRepository{}
+	userRepository.SetGetCurrentIdValue(user.GetCurrentIdValue{UserId: "some_id", Err: nil})
+	middleware := NewUserIdMiddleware(GetUserIdHandler{}, &userRepository)
+	middleware.SetUserIdKey(defaultUserIdKey())
+	request := httptest.NewRequest("GET", "http://example.com", nil)
+	writer := httptest.NewRecorder()
+	return middleware, request, writer
+}
+
+func TestGetUserIdCallsRepositoryWithRequestContext(t *testing.T) {
+	middleware, request, writer := userIdMiddlewareTestSetup()
+
+	middleware.ServeHTTP(writer, request)
+
+	fakeRepository := middleware.GetUserRepository().(*user.FakeUserRepository)
+	testtools.AssertEqual(t, fakeRepository.GetGetCurrentIdArgs().Context, request.Context())
+}
+
+func TestGetUserReturnsInternalErrorOnRepositoryError(t *testing.T) {
+	middleware, request, writer := userIdMiddlewareTestSetup()
+	userRepository := user.FakeUserRepository{}
+	userRepository.SetGetCurrentIdValue(user.GetCurrentIdValue{UserId: "", Err: errors.New("test error")})
+	middleware.SetUserRepository(&userRepository)
+
+	middleware.ServeHTTP(writer, request)
+
+	testtools.AssertEqual(t, writer.Result().StatusCode, http.StatusInternalServerError)
+}
+
+func TestUserIsPlacedInExpectedContextKey(t *testing.T) {
+	middleware, request, writer := userIdMiddlewareTestSetup()
+
+	middleware.ServeHTTP(writer, request)
+
+	testtools.AssertEqual(t, writer.Body.String(), "some_id")
+}
+
+func TestUserIdMiddlewareReturnsStatusCodeofTheHandler(t *testing.T) {
+	middleware, request, writer := userIdMiddlewareTestSetup()
+
+	middleware.ServeHTTP(writer, request)
+
+	testtools.AssertEqual(t, writer.Code, http.StatusContinue)
+}

--- a/internal/playlist/spotify/spotify_playlist_repository.go
+++ b/internal/playlist/spotify/spotify_playlist_repository.go
@@ -196,7 +196,7 @@ func (r *SpotifyPlaylistRepository) searchPlaylistOptions(
 	queryParams.Set("type", "playlist")
 	queryParams.Set("limit", fmt.Sprintf("%d", limit))
 	url := fmt.Sprintf("https://%s/v1/search?%s", r.host, queryParams.Encode())
-	httpOptions := httpsender.NewHTTPRequestOptions(url, httpsender.POST, 201)
+	httpOptions := httpsender.NewHTTPRequestOptions(url, httpsender.GET, 200)
 	httpOptions.SetHeaders(r.GetSpotifyBaseHeaders(token))
 	return httpOptions
 }

--- a/internal/playlist/spotify/spotify_playlist_repository_test.go
+++ b/internal/playlist/spotify/spotify_playlist_repository_test.go
@@ -171,7 +171,7 @@ func expectedSearchPlaylistHttpOptions() httpsender.HTTPRequestOptions {
 		defaultSearchPlaylistLimit(),
 		defaultPlaylistName(),
 	)
-	options := httpsender.NewHTTPRequestOptions(url, httpsender.POST, 201)
+	options := httpsender.NewHTTPRequestOptions(url, httpsender.GET, 200)
 	options.SetHeaders(defaultHeaders())
 	return options
 }

--- a/internal/user/fake_user_repository.go
+++ b/internal/user/fake_user_repository.go
@@ -1,0 +1,31 @@
+package user
+
+import "context"
+
+type GetCurrentIdArgs struct {
+	Context context.Context
+}
+
+type GetCurrentIdValue struct {
+	UserId string
+	Err    error
+}
+
+type FakeUserRepository struct {
+	currentIdArgs  GetCurrentIdArgs
+	currentIdValue GetCurrentIdValue
+}
+
+func (r *FakeUserRepository) GetCurrentUserId(ctx context.Context) (string, error) {
+	r.currentIdArgs = GetCurrentIdArgs{Context: ctx}
+	return r.currentIdValue.UserId, r.currentIdValue.Err
+
+}
+
+func (r FakeUserRepository) GetGetCurrentIdArgs() GetCurrentIdArgs {
+	return r.currentIdArgs
+}
+
+func (r *FakeUserRepository) SetGetCurrentIdValue(value GetCurrentIdValue) {
+	r.currentIdValue = value
+}

--- a/internal/user/spotify/spotify_user_repository.go
+++ b/internal/user/spotify/spotify_user_repository.go
@@ -1,0 +1,68 @@
+package spotify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	types "festwrap/internal"
+	httpsender "festwrap/internal/http/sender"
+	"festwrap/internal/serialization"
+)
+
+type SpotifyUserRepository struct {
+	tokenKey     types.ContextKey
+	deserializer serialization.Deserializer[spotifyUserResponse]
+	httpSender   httpsender.HTTPRequestSender
+	host         string
+}
+
+func NewSpotifyUserRepository(httpSender httpsender.HTTPRequestSender) SpotifyUserRepository {
+	return SpotifyUserRepository{
+		tokenKey:     "token",
+		deserializer: serialization.NewJsonDeserializer[spotifyUserResponse](),
+		httpSender:   httpSender,
+		host:         "api.spotify.com",
+	}
+}
+
+func (r SpotifyUserRepository) GetCurrentUserId(ctx context.Context) (string, error) {
+	token, ok := ctx.Value(r.tokenKey).(string)
+	if !ok {
+		return "", errors.New("could not retrieve token from context")
+	}
+
+	responseBody, err := r.httpSender.Send(r.getCurrentUserIdHTTPOptions(token))
+	if err != nil {
+		return "", fmt.Errorf("could not get current user: %v", err.Error())
+	}
+
+	var response spotifyUserResponse
+	err = r.deserializer.Deserialize(*responseBody, &response)
+	if err != nil {
+		return "", fmt.Errorf("deserialization error: %v", err.Error())
+	}
+
+	return response.UserId, nil
+}
+
+func (r SpotifyUserRepository) getCurrentUserIdHTTPOptions(accessToken string) httpsender.HTTPRequestOptions {
+	url := fmt.Sprintf("https://%s/v1/me", r.host)
+	httpOptions := httpsender.NewHTTPRequestOptions(url, httpsender.GET, 200)
+	httpOptions.SetHeaders(
+		map[string]string{"Authorization": fmt.Sprintf("Bearer %s", accessToken)},
+	)
+	return httpOptions
+}
+
+func (r *SpotifyUserRepository) GetDeserializer() serialization.Deserializer[spotifyUserResponse] {
+	return r.deserializer
+}
+
+func (r *SpotifyUserRepository) SetDeserializer(deserializer serialization.Deserializer[spotifyUserResponse]) {
+	r.deserializer = deserializer
+}
+
+func (r *SpotifyUserRepository) SetTokenKey(key types.ContextKey) {
+	r.tokenKey = key
+}

--- a/internal/user/spotify/spotify_user_repository_test.go
+++ b/internal/user/spotify/spotify_user_repository_test.go
@@ -1,0 +1,143 @@
+package spotify
+
+import (
+	"context"
+	"errors"
+	types "festwrap/internal"
+	httpsender "festwrap/internal/http/sender"
+	"festwrap/internal/serialization"
+	"festwrap/internal/testtools"
+	"testing"
+)
+
+func defaultTokenKey() types.ContextKey {
+	return "myKey"
+}
+
+func defaultContext() context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, defaultTokenKey(), "some_token")
+	return ctx
+}
+
+func defaultResponse() []byte {
+	return []byte(`{"id":"my_id"}`)
+}
+
+func defaultDeserializedResponse() spotifyUserResponse {
+	return spotifyUserResponse{UserId: "userId"}
+}
+
+func defaultSender() *httpsender.FakeHTTPSender {
+	sender := &httpsender.FakeHTTPSender{}
+	response := defaultResponse()
+	sender.SetResponse(&response)
+	return sender
+}
+
+func defaultDeserializer() *serialization.FakeDeserializer[spotifyUserResponse] {
+	deserializer := &serialization.FakeDeserializer[spotifyUserResponse]{}
+	deserializer.SetResponse(defaultDeserializedResponse())
+	return deserializer
+}
+
+func spotifyUserRepository(sender httpsender.HTTPRequestSender) SpotifyUserRepository {
+	repository := NewSpotifyUserRepository(sender)
+	repository.SetDeserializer(defaultDeserializer())
+	repository.SetTokenKey(defaultTokenKey())
+	return repository
+}
+
+func expectedHttpOptions() httpsender.HTTPRequestOptions {
+	url := "https://api.spotify.com/v1/me"
+	options := httpsender.NewHTTPRequestOptions(url, httpsender.GET, 200)
+	options.SetHeaders(
+		map[string]string{"Authorization": "Bearer some_token"},
+	)
+	return options
+}
+
+func TestRepositoryMethodsReturnErrorWhenInvalidToken(t *testing.T) {
+	tests := map[string]struct {
+		repositoryTokenKey types.ContextKey
+		tokenKey           types.ContextKey
+		tokenVal           interface{}
+	}{
+		"returns error when token is wrong type": {
+			repositoryTokenKey: "matchingKey",
+			tokenKey:           "matchingKey",
+			tokenVal:           1234,
+		},
+		"returns error when token is missing": {
+			repositoryTokenKey: "someKey",
+			tokenKey:           "otherKey",
+			tokenVal:           "myToken",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, test.tokenKey, test.tokenVal)
+			repository := spotifyUserRepository(defaultSender())
+			repository.SetTokenKey(test.repositoryTokenKey)
+
+			_, err := repository.GetCurrentUserId(ctx)
+			testtools.AssertErrorIsNotNil(t, err)
+		})
+	}
+}
+
+func TestGetCurrentUserIdSendsRequestWithProperOptions(t *testing.T) {
+	sender := defaultSender()
+	repository := spotifyUserRepository(sender)
+
+	_, err := repository.GetCurrentUserId(defaultContext())
+
+	testtools.AssertErrorIsNil(t, err)
+	testtools.AssertEqual(t, sender.GetSendArgs(), expectedHttpOptions())
+}
+
+func TestGetCurrentUserReturnsErrorOnSendError(t *testing.T) {
+	sender := &httpsender.FakeHTTPSender{}
+	sender.SetError(errors.New("test error"))
+	repository := spotifyUserRepository(sender)
+
+	_, err := repository.GetCurrentUserId(defaultContext())
+
+	testtools.AssertErrorIsNotNil(t, err)
+}
+
+func TestGetCurrentUserCallsDeserializeWithSendResponseBody(t *testing.T) {
+	repository := spotifyUserRepository(defaultSender())
+
+	_, err := repository.GetCurrentUserId(defaultContext())
+
+	testtools.AssertErrorIsNil(t, err)
+	deserializer := repository.GetDeserializer().(*serialization.FakeDeserializer[spotifyUserResponse])
+	testtools.AssertEqual(t, deserializer.GetArgs(), defaultResponse())
+}
+
+func TestGetCurrentUserReturnsErrorOnResponseBodyDeserializationError(t *testing.T) {
+	deserializer := defaultDeserializer()
+	deserializer.SetError(errors.New("test error"))
+	repository := spotifyUserRepository(defaultSender())
+	repository.SetDeserializer(deserializer)
+
+	_, err := repository.GetCurrentUserId(defaultContext())
+
+	testtools.AssertErrorIsNotNil(t, err)
+}
+
+func TestGetCurrentUserReturnsFirstSongFoundIntegration(t *testing.T) {
+	testtools.SkipOnShortRun(t)
+
+	repository := spotifyUserRepository(defaultSender())
+	repository.SetDeserializer(serialization.NewJsonDeserializer[spotifyUserResponse]())
+
+	actual, err := repository.GetCurrentUserId(defaultContext())
+
+	expected := "my_id"
+	testtools.AssertErrorIsNil(t, err)
+	testtools.AssertEqual(t, actual, expected)
+}

--- a/internal/user/spotify/spotify_user_response.go
+++ b/internal/user/spotify/spotify_user_response.go
@@ -1,0 +1,5 @@
+package spotify
+
+type spotifyUserResponse struct {
+	UserId string `json:"id"`
+}

--- a/internal/user/user_repository.go
+++ b/internal/user/user_repository.go
@@ -1,0 +1,7 @@
+package user
+
+import "context"
+
+type UserRepository interface {
+	GetCurrentUserId(ctx context.Context) (string, error)
+}


### PR DESCRIPTION
# Description

Adds the playlist search endpoint into the service. Spotify returns all playlists, not only the ones owned by the user. However, I observed that user owned playlists are always placed first. In order to filter those playlists, I added a middleware that extracts the current user id and places it into the Context. Then, in the repository, we can filter out the playlists whose owner do not match the current user.

Note that for simplicity we are not paginating the search results. This makes sense, for now, in the current use case.

# Test

If we locally request a playlist, we see we obtain proper results. First, starrt the app locally:

```shell
go run cmd/main.go
```

Then, in a separate terminal, type:

```
curl --location 'http://localhost:8080/playlists/search?name=Jera&limit=5' \
      --header 'Authorization: Bearer <token>'
```

I get:

```json
[{"Name":"Jera 2023","Description":"","IsPublic":true},{"Name":"Jera 2025","Description":"","IsPublic":true}]
```

See [frontend](https://github.com/DanielMoraDC/festwrap-ui) on how to obtain a valid token.