### PR TITLE
docs: add instructions to run container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 ROOT ?= ./
 IMAGE_NAME ?= "festwrap-server"
 IMAGE_TAG ?= "latest"
+CONTAINER_NAME ?= "festwrap-server"
+PORT ?= 8080
 
 .PHONY: pre-commit-install
 pre-commit-install:
@@ -26,3 +28,16 @@ run-tests: run-unit-tests run-integration-tests
 .PHONE: build-image
 build-image:
 	docker build -f Dockerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .
+
+
+.PHONE: run-server
+run-server:
+	@docker run --name $(CONTAINER_NAME) \
+        -d -e FESTWRAP_PORT=$(PORT) \
+        -p $(PORT):$(PORT) \
+        -t ${IMAGE_NAME}:${IMAGE_TAG}
+
+
+.PHONE: stop-server
+stop-server:
+	@docker container stop $(CONTAINER_NAME) && docker container rm $(CONTAINER_NAME)

--- a/README.md
+++ b/README.md
@@ -28,13 +28,37 @@ make run-tests
 
 ## Running the API
 
-To run the API, you can type:
+### Run the app
+
+To run the API locally, you can type:
 
 ```shell
 go run cmd/main.go
 ```
 
-Then you can query it locally by typing:
+### Run the app container
+
+To run the app Docker image, first make sure to build the image:
+
+```shell
+make build-image
+```
+
+Then start the container:
+
+```shell
+make run-server
+```
+
+To stop the container:
+
+```shell
+make stop-server
+```
+
+## Calling the API
+
+Once the API is up, you can query it locally by typing:
 
 ```shell
 curl --location 'http://localhost:8080/artists/search?name=<artist>' \


### PR DESCRIPTION
# Description

Adds commands to run and stop the containerized server and documents it in the README.