### PR TITLE
chore: FW-66 Implement create in service

### DIFF
--- a/internal/playlist/concurrent_playlist_service.go
+++ b/internal/playlist/concurrent_playlist_service.go
@@ -33,6 +33,10 @@ func NewConcurrentPlaylistService(
 	}
 }
 
+func (s *ConcurrentPlaylistService) CreatePlaylist(ctx context.Context, playlist Playlist) error {
+	return s.playlistRepository.CreatePlaylist(ctx, playlist)
+}
+
 func (s *ConcurrentPlaylistService) AddSetlist(ctx context.Context, playlistId string, artist string) error {
 	setlist, err := s.setlistRepository.GetSetlist(artist, s.minSongs)
 	if err != nil {

--- a/internal/playlist/concurrent_playlist_service_test.go
+++ b/internal/playlist/concurrent_playlist_service_test.go
@@ -14,6 +14,10 @@ func defaultContext() context.Context {
 	return context.Background()
 }
 
+func defaultPlaylist() Playlist {
+	return Playlist{Name: "My playlist", Description: "Some playlist", IsPublic: true}
+}
+
 func defaultPlaylistId() string {
 	return "myPlaylist"
 }
@@ -100,6 +104,28 @@ func testSetup() (FakePlaylistRepository, setlist.FakeSetlistRepository, song.Fa
 	setlistRepository := newFakeSetlistRepository()
 	songRepository := newFakeSongRepository()
 	return playlistRepository, setlistRepository, songRepository
+}
+
+func TestCreatePlaylistRepositoryCalledWithArgs(t *testing.T) {
+	playlistRepository, setlistRepository, songRepository := testSetup()
+	service := NewConcurrentPlaylistService(&playlistRepository, &setlistRepository, &songRepository)
+
+	err := service.CreatePlaylist(defaultContext(), defaultPlaylist())
+
+	actual := playlistRepository.GetCreatePlaylistArgs()
+	expected := CreatePlaylistArgs{Context: defaultContext(), Playlist: defaultPlaylist()}
+	testtools.AssertErrorIsNil(t, err)
+	testtools.AssertEqual(t, actual, expected)
+}
+
+func TestCreatePlaylistReturnsErrorIfRepositoryErrors(t *testing.T) {
+	playlistRepository, setlistRepository, songRepository := testSetup()
+	playlistRepository.SetError(errors.New("test error"))
+	service := NewConcurrentPlaylistService(&playlistRepository, &setlistRepository, &songRepository)
+
+	err := service.CreatePlaylist(defaultContext(), defaultPlaylist())
+
+	testtools.AssertErrorIsNotNil(t, err)
 }
 
 func TestAddSetlistSetlistRepositoryCalledWithArgs(t *testing.T) {

--- a/internal/playlist/fake_playlist_repository.go
+++ b/internal/playlist/fake_playlist_repository.go
@@ -13,7 +13,6 @@ type AddSongsArgs struct {
 
 type CreatePlaylistArgs struct {
 	Context  context.Context
-	UserId   string
 	Playlist Playlist
 }
 
@@ -35,8 +34,8 @@ func NewFakePlaylistRepository() FakePlaylistRepository {
 	return FakePlaylistRepository{searchedPlaylists: []Playlist{}}
 }
 
-func (s *FakePlaylistRepository) CreatePlaylist(ctx context.Context, userId string, playlist Playlist) error {
-	s.createPlaylistArgs = CreatePlaylistArgs{Context: ctx, UserId: userId, Playlist: playlist}
+func (s *FakePlaylistRepository) CreatePlaylist(ctx context.Context, playlist Playlist) error {
+	s.createPlaylistArgs = CreatePlaylistArgs{Context: ctx, Playlist: playlist}
 	return s.err
 }
 

--- a/internal/playlist/fake_playlist_repository.go
+++ b/internal/playlist/fake_playlist_repository.go
@@ -59,7 +59,7 @@ func (s *FakePlaylistRepository) GetAddSongArgs() AddSongsArgs {
 	return s.addSongArgs
 }
 
-func (s *FakePlaylistRepository) GetCreatePlaylistSongArgs() CreatePlaylistArgs {
+func (s *FakePlaylistRepository) GetCreatePlaylistArgs() CreatePlaylistArgs {
 	return s.createPlaylistArgs
 }
 

--- a/internal/playlist/playlist_repository.go
+++ b/internal/playlist/playlist_repository.go
@@ -6,7 +6,7 @@ import (
 )
 
 type PlaylistRepository interface {
-	CreatePlaylist(ctx context.Context, userId string, playlist Playlist) error
+	CreatePlaylist(ctx context.Context, playlist Playlist) error
 	SearchPlaylist(ctx context.Context, name string, limit int) ([]Playlist, error)
 	AddSongs(ctx context.Context, playlistId string, songs []song.Song) error
 }

--- a/internal/playlist/playlist_service.go
+++ b/internal/playlist/playlist_service.go
@@ -3,5 +3,6 @@ package playlist
 import "context"
 
 type PlaylistService interface {
+	CreatePlaylist(ctx context.Context, playlist Playlist) error
 	AddSetlist(ctx context.Context, playlistId string, artist string) error
 }

--- a/internal/playlist/spotify/spotify_playlist_repository.go
+++ b/internal/playlist/spotify/spotify_playlist_repository.go
@@ -63,10 +63,15 @@ func (r *SpotifyPlaylistRepository) AddSongs(ctx context.Context, playlistId str
 	return nil
 }
 
-func (r *SpotifyPlaylistRepository) CreatePlaylist(ctx context.Context, userId string, playlist playlist.Playlist) error {
+func (r *SpotifyPlaylistRepository) CreatePlaylist(ctx context.Context, playlist playlist.Playlist) error {
 	token, ok := ctx.Value(r.tokenKey).(string)
 	if !ok {
 		return errors.NewCannotCreatePlaylistError("Could not retrieve token from context")
+	}
+
+	userId, ok := ctx.Value(r.userIdKey).(string)
+	if !ok {
+		return errors.NewCannotCreatePlaylistError("Could not retrieve user id from context")
 	}
 
 	body, err := r.playlistSerializer.Serialize(

--- a/internal/playlist/spotify/spotify_playlist_repository_test.go
+++ b/internal/playlist/spotify/spotify_playlist_repository_test.go
@@ -246,7 +246,7 @@ func TestAddSongsReturnsErrorOnSendError(t *testing.T) {
 func TestAddSongsSerializesInputPlaylist(t *testing.T) {
 	repository := spotifyPlaylistRepository()
 
-	repository.CreatePlaylist(defaultContext(), defaultUserId(), defaultPlaylist())
+	repository.CreatePlaylist(defaultContext(), defaultPlaylist())
 
 	expected := SpotifyPlaylist{Name: "my-playlist", Description: "some playlist", IsPublic: false}
 	actual := repository.GetPlaylistSerializer().(*serialization.FakeSerializer[SpotifyPlaylist]).GetArgs()
@@ -259,7 +259,7 @@ func TestCreatePlaylistReturnsErrorOnPlaylistSerializationError(t *testing.T) {
 	serializer.SetError(errors.New("test playlist error"))
 	repository.SetPlaylistSerializer(serializer)
 
-	err := repository.CreatePlaylist(defaultContext(), defaultUserId(), defaultPlaylist())
+	err := repository.CreatePlaylist(defaultContext(), defaultPlaylist())
 
 	testtools.AssertErrorIsNotNil(t, err)
 }
@@ -267,7 +267,7 @@ func TestCreatePlaylistReturnsErrorOnPlaylistSerializationError(t *testing.T) {
 func TestCreatePlaylistSendsCreateRequestWithOptions(t *testing.T) {
 	repository := spotifyPlaylistRepository()
 
-	repository.CreatePlaylist(defaultContext(), defaultUserId(), defaultPlaylist())
+	repository.CreatePlaylist(defaultContext(), defaultPlaylist())
 
 	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
 	testtools.AssertEqual(t, actual, expectedCreatePlaylistHttpOptions())
@@ -277,7 +277,7 @@ func TestCreatePlaylistReturnsErrorOnSendError(t *testing.T) {
 	repository := spotifyPlaylistRepository()
 	repository.SetHTTPSender(errorSender())
 
-	err := repository.CreatePlaylist(defaultContext(), defaultUserId(), defaultPlaylist())
+	err := repository.CreatePlaylist(defaultContext(), defaultPlaylist())
 
 	testtools.AssertErrorIsNotNil(t, err)
 }
@@ -340,7 +340,7 @@ func TestCreatePlaylistSendsOptionsUsingSerializerIntegration(t *testing.T) {
 	repository := spotifyPlaylistRepository()
 	repository.SetPlaylistSerializer(&serializer)
 
-	repository.CreatePlaylist(defaultContext(), defaultUserId(), defaultPlaylist())
+	repository.CreatePlaylist(defaultContext(), defaultPlaylist())
 
 	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
 	testtools.AssertEqual(t, actual, expectedCreatePlaylistHttpOptions())
@@ -391,7 +391,7 @@ func TestRepositoryMethodsReturnErrorWhenInvalidToken(t *testing.T) {
 			err := repository.AddSongs(ctx, defaultPlaylistId(), defaultSongs())
 			testtools.AssertErrorIsNotNil(t, err)
 
-			err = repository.CreatePlaylist(ctx, defaultUserId(), defaultPlaylist())
+			err = repository.CreatePlaylist(ctx, defaultPlaylist())
 			testtools.AssertErrorIsNotNil(t, err)
 
 			_, err = repository.SearchPlaylist(ctx, defaultPlaylistName(), defaultSearchPlaylistLimit())
@@ -426,6 +426,9 @@ func TestRepositoryMethodsReturnErrorWhenInvalidUserId(t *testing.T) {
 			repository.SetUserIdKey(test.repositoryUserIdKey)
 
 			_, err := repository.SearchPlaylist(ctx, defaultPlaylistName(), defaultSearchPlaylistLimit())
+			testtools.AssertErrorIsNotNil(t, err)
+
+			err = repository.CreatePlaylist(ctx, defaultPlaylist())
 			testtools.AssertErrorIsNotNil(t, err)
 		})
 	}


### PR DESCRIPTION
# Description

Adds the create playlist functionality to the playlist service, which wraps the repository.

Moreover, standardizes playlist repository to use user id from context so it is consistent with other repositories in the code base.