### PR TITLE
fix: return camel case names on playlist search

### DIFF
--- a/internal/playlist/playlist.go
+++ b/internal/playlist/playlist.go
@@ -1,7 +1,7 @@
 package playlist
 
 type Playlist struct {
-	Name        string
-	Description string
-	IsPublic    bool
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	IsPublic    bool   `json:"isPublic"`
 }


### PR DESCRIPTION
# Description

Changes the attribute names in the return JSON so they are consistent with the other endpoints.

# Testing

Before:

```shell
'http://localhost:8080/playlists/search?name=Emo&limit=4' -H 'Authorization: Bearer <token>'
# [{"Name":"Emo rules","Description":"","IsPublic":true}]
```

After:

```shell
curl 'http://localhost:8080/playlists/search?name=Emo&limit=4' -H 'Authorization: Bearer <token>'
# [{"name":"Emo rules","description":"","isPublic":true}]
```
