### PR TITLE
chore: FW-72 use testify dependency for tests

### DIFF
--- a/cmd/handler/search/search_test.go
+++ b/cmd/handler/search/search_test.go
@@ -12,6 +12,8 @@ import (
 	"festwrap/internal/logging"
 	"festwrap/internal/serialization"
 	"festwrap/internal/testtools"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type Result struct {
@@ -82,7 +84,7 @@ func TestBadRequestIfNameNotProvided(t *testing.T) {
 
 	handler.ServeHTTP(writer, request)
 
-	testtools.AssertEqual(t, writer.Code, http.StatusBadRequest)
+	assert.Equal(t, writer.Code, http.StatusBadRequest)
 }
 
 func TestLimitStatusCodeDependingOnValue(t *testing.T) {
@@ -123,7 +125,7 @@ func TestLimitStatusCodeDependingOnValue(t *testing.T) {
 
 			handler.ServeHTTP(writer, request)
 
-			testtools.AssertEqual(t, writer.Code, test.status)
+			assert.Equal(t, writer.Code, test.status)
 		})
 	}
 }
@@ -137,9 +139,9 @@ func TestSearcherCalledWithParams(t *testing.T) {
 	handler.ServeHTTP(httptest.NewRecorder(), request)
 
 	actual := searcher.GetSearchArgs()
-	testtools.AssertEqual(t, actual.Context, request.Context())
-	testtools.AssertEqual(t, fmt.Sprint(actual.Limit), defaultQueryParams()["limit"])
-	testtools.AssertEqual(t, actual.Name, defaultQueryParams()["name"])
+	assert.Equal(t, actual.Context, request.Context())
+	assert.Equal(t, fmt.Sprint(actual.Limit), defaultQueryParams()["limit"])
+	assert.Equal(t, actual.Name, defaultQueryParams()["name"])
 }
 
 func TestSearchReturnsInternalErrorOnEncoderError(t *testing.T) {
@@ -150,7 +152,7 @@ func TestSearchReturnsInternalErrorOnEncoderError(t *testing.T) {
 
 	handler.ServeHTTP(writer, request)
 
-	testtools.AssertEqual(t, writer.Code, http.StatusInternalServerError)
+	assert.Equal(t, writer.Code, http.StatusInternalServerError)
 }
 
 func TestSearchReturnsExpectedResult(t *testing.T) {
@@ -160,6 +162,6 @@ func TestSearchReturnsExpectedResult(t *testing.T) {
 
 	handler.ServeHTTP(writer, request)
 
-	testtools.AssertEqual(t, writer.Code, http.StatusOK)
-	testtools.AssertEqual(t, unmarshalSearchResponse(t, writer.Body.Bytes()), defaultResults())
+	assert.Equal(t, writer.Code, http.StatusOK)
+	assert.Equal(t, unmarshalSearchResponse(t, writer.Body.Bytes()), defaultResults())
 }

--- a/cmd/middleware/auth_token_test.go
+++ b/cmd/middleware/auth_token_test.go
@@ -7,7 +7,8 @@ import (
 	"testing"
 
 	types "festwrap/internal"
-	"festwrap/internal/testtools"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type GetTokenHandler struct{}
@@ -35,7 +36,7 @@ func TestBadRequestErrorOnMissingAuthHeader(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	testtools.AssertEqual(t, writer.Code, http.StatusBadRequest)
+	assert.Equal(t, writer.Code, http.StatusBadRequest)
 }
 
 func TestUnprocessableEntityErrorOnWronglyFormattedAuthHeader(t *testing.T) {
@@ -44,7 +45,7 @@ func TestUnprocessableEntityErrorOnWronglyFormattedAuthHeader(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	testtools.AssertEqual(t, writer.Code, http.StatusUnprocessableEntity)
+	assert.Equal(t, writer.Code, http.StatusUnprocessableEntity)
 }
 
 func TestTokenIsPlacedInExpectedContextKey(t *testing.T) {
@@ -53,7 +54,7 @@ func TestTokenIsPlacedInExpectedContextKey(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	testtools.AssertEqual(t, writer.Body.String(), "1234")
+	assert.Equal(t, writer.Body.String(), "1234")
 }
 
 func TestMiddlewareReturnsStatusCodeofTheHandler(t *testing.T) {
@@ -62,5 +63,5 @@ func TestMiddlewareReturnsStatusCodeofTheHandler(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	testtools.AssertEqual(t, writer.Code, http.StatusAccepted)
+	assert.Equal(t, writer.Code, http.StatusAccepted)
 }

--- a/cmd/middleware/user_id_test.go
+++ b/cmd/middleware/user_id_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 
 	types "festwrap/internal"
-	"festwrap/internal/testtools"
 	"festwrap/internal/user"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type GetUserIdHandler struct{}
@@ -48,7 +49,7 @@ func TestGetUserIdCallsRepositoryWithRequestContext(t *testing.T) {
 	middleware.ServeHTTP(writer, request)
 
 	fakeRepository := middleware.GetUserRepository().(*user.FakeUserRepository)
-	testtools.AssertEqual(t, fakeRepository.GetGetCurrentIdArgs().Context, request.Context())
+	assert.Equal(t, fakeRepository.GetGetCurrentIdArgs().Context, request.Context())
 }
 
 func TestGetUserReturnsInternalErrorOnRepositoryError(t *testing.T) {
@@ -59,7 +60,7 @@ func TestGetUserReturnsInternalErrorOnRepositoryError(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	testtools.AssertEqual(t, writer.Result().StatusCode, http.StatusInternalServerError)
+	assert.Equal(t, writer.Result().StatusCode, http.StatusInternalServerError)
 }
 
 func TestUserIsPlacedInExpectedContextKey(t *testing.T) {
@@ -67,7 +68,7 @@ func TestUserIsPlacedInExpectedContextKey(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	testtools.AssertEqual(t, writer.Body.String(), "some_id")
+	assert.Equal(t, writer.Body.String(), "some_id")
 }
 
 func TestUserIdMiddlewareReturnsStatusCodeofTheHandler(t *testing.T) {
@@ -75,5 +76,5 @@ func TestUserIdMiddlewareReturnsStatusCodeofTheHandler(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	testtools.AssertEqual(t, writer.Code, http.StatusContinue)
+	assert.Equal(t, writer.Code, http.StatusContinue)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module festwrap
 
 go 1.22
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/artist/spotify/spotify_artist_repository_test.go
+++ b/internal/artist/spotify/spotify_artist_repository_test.go
@@ -11,6 +11,8 @@ import (
 	"festwrap/internal/serialization"
 	"festwrap/internal/testtools"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func defaultSearchName() string {
@@ -128,8 +130,8 @@ func TestSearchArtistSendsRequestWithProperOptions(t *testing.T) {
 
 	_, err := repository.SearchArtist(defaultContext(), defaultSearchName(), defaultLimit())
 
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, sender.GetSendArgs(), expectedHttpOptions())
+	assert.Nil(t, err)
+	assert.Equal(t, sender.GetSendArgs(), expectedHttpOptions())
 }
 
 func TestSearchArtistReturnsErrorOnWrongKeyType(t *testing.T) {
@@ -139,7 +141,7 @@ func TestSearchArtistReturnsErrorOnWrongKeyType(t *testing.T) {
 
 	_, err := repository.SearchArtist(ctx, defaultSearchName(), defaultLimit())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestSearchArtistReturnsErrorOnSendError(t *testing.T) {
@@ -149,7 +151,7 @@ func TestSearchArtistReturnsErrorOnSendError(t *testing.T) {
 
 	_, err := repository.SearchArtist(defaultContext(), defaultSearchName(), defaultLimit())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestSearchArtistCallsDeserializeWithSendResponseBody(t *testing.T) {
@@ -159,8 +161,8 @@ func TestSearchArtistCallsDeserializeWithSendResponseBody(t *testing.T) {
 
 	_, err := repository.SearchArtist(defaultContext(), defaultSearchName(), defaultLimit())
 
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, deserializer.GetArgs(), defaultResponse())
+	assert.Nil(t, err)
+	assert.Equal(t, deserializer.GetArgs(), defaultResponse())
 }
 
 func TestSearchArtistsReturnsErrorOnResponseBodyDeserializationError(t *testing.T) {
@@ -171,7 +173,7 @@ func TestSearchArtistsReturnsErrorOnResponseBodyDeserializationError(t *testing.
 
 	_, err := repository.SearchArtist(defaultContext(), defaultSearchName(), defaultLimit())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestSearchArtistReturnsDeserializedArtists(t *testing.T) {
@@ -179,7 +181,7 @@ func TestSearchArtistReturnsDeserializedArtists(t *testing.T) {
 
 	artists, _ := repository.SearchArtist(defaultContext(), defaultSearchName(), defaultLimit())
 
-	testtools.AssertEqual(t, artists, defaultArtists())
+	assert.Equal(t, artists, defaultArtists())
 }
 
 func TestSearchArtistReturnsEmptyIfNoneFound(t *testing.T) {
@@ -191,7 +193,7 @@ func TestSearchArtistReturnsEmptyIfNoneFound(t *testing.T) {
 
 	artists, _ := repository.SearchArtist(defaultContext(), defaultSearchName(), defaultLimit())
 
-	testtools.AssertEqual(t, artists, []artist.Artist{})
+	assert.Equal(t, artists, []artist.Artist{})
 }
 
 func TestSearchArtistReturnsDeserializedArtistsIntegration(t *testing.T) {
@@ -205,5 +207,5 @@ func TestSearchArtistReturnsDeserializedArtistsIntegration(t *testing.T) {
 
 	artists, _ := repository.SearchArtist(defaultContext(), defaultSearchName(), defaultLimit())
 
-	testtools.AssertEqual(t, artists, integrationArtists())
+	assert.Equal(t, artists, integrationArtists())
 }

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,9 +1,10 @@
 package env
 
 import (
-	"festwrap/internal/testtools"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetEnvReturnsDefaultValueIfDoesntExist(t *testing.T) {
@@ -12,7 +13,7 @@ func TestGetEnvReturnsDefaultValueIfDoesntExist(t *testing.T) {
 		defaultValue := 2
 		value, _ := GetEnvWithDefault("MY_KEY", defaultValue)
 
-		testtools.AssertEqual(t, value, defaultValue)
+		assert.Equal(t, value, defaultValue)
 	})
 
 	t.Run("string", func(t *testing.T) {
@@ -20,7 +21,7 @@ func TestGetEnvReturnsDefaultValueIfDoesntExist(t *testing.T) {
 		defaultValue := "something"
 		value, _ := GetEnvWithDefault("MY_KEY", defaultValue)
 
-		testtools.AssertEqual(t, value, defaultValue)
+		assert.Equal(t, value, defaultValue)
 	})
 }
 
@@ -31,7 +32,7 @@ func TestGetEnvReturnsExistingEnvVariable(t *testing.T) {
 		os.Setenv(key, value)
 		actual, _ := GetEnvWithDefault(key, 0)
 
-		testtools.AssertEqual(t, actual, 42)
+		assert.Equal(t, actual, 42)
 	})
 
 	t.Run("string", func(t *testing.T) {
@@ -40,7 +41,7 @@ func TestGetEnvReturnsExistingEnvVariable(t *testing.T) {
 		os.Setenv(key, value)
 		actual, _ := GetEnvWithDefault(key, "")
 
-		testtools.AssertEqual(t, actual, value)
+		assert.Equal(t, actual, value)
 	})
 }
 
@@ -51,5 +52,5 @@ func TestGetEnvReturnsErrorOnInvalidEnvVar(t *testing.T) {
 
 	_, err := GetEnvWithDefault(key, 0)
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }

--- a/internal/http/sender/base_sender_test.go
+++ b/internal/http/sender/base_sender_test.go
@@ -9,6 +9,8 @@ import (
 
 	httpclient "festwrap/internal/http/client"
 	"festwrap/internal/testtools"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func defaultRequestBody() []byte {
@@ -57,8 +59,8 @@ func TestSendRequestHasProvidedMethod(t *testing.T) {
 
 	expected := client.GetRequestArg()
 	actual := string(options.GetMethod())
-	testtools.AssertEqual(t, actual, expected.Method)
-	testtools.AssertErrorIsNil(t, err)
+	assert.Equal(t, actual, expected.Method)
+	assert.Nil(t, err)
 }
 
 func TestSendRequestHasProvidedUrl(t *testing.T) {
@@ -68,8 +70,8 @@ func TestSendRequestHasProvidedUrl(t *testing.T) {
 
 	expected := client.GetRequestArg()
 	actual := options.GetUrl()
-	testtools.AssertEqual(t, actual, expected.URL.String())
-	testtools.AssertErrorIsNil(t, err)
+	assert.Equal(t, actual, expected.URL.String())
+	assert.Nil(t, err)
 }
 
 func TestSendRequestHasProvidedBody(t *testing.T) {
@@ -79,8 +81,8 @@ func TestSendRequestHasProvidedBody(t *testing.T) {
 
 	expected := client.GetRequestArg()
 	actual := options.GetBody()
-	testtools.AssertEqual(t, actual, readBodyFromRequest(t, expected))
-	testtools.AssertErrorIsNil(t, err)
+	assert.Equal(t, actual, readBodyFromRequest(t, expected))
+	assert.Nil(t, err)
 }
 
 func TestSendRequestDoesNotIncludeBodyIfNotProvided(t *testing.T) {
@@ -90,8 +92,9 @@ func TestSendRequestDoesNotIncludeBodyIfNotProvided(t *testing.T) {
 	_, err := sender.Send(options)
 
 	expected := client.GetRequestArg()
-	testtools.AssertIsNil(t, expected.Body)
-	testtools.AssertErrorIsNil(t, err)
+
+	assert.Nil(t, expected.Body)
+	assert.Nil(t, err)
 }
 
 func TestSendRequestUsesHeaders(t *testing.T) {
@@ -106,7 +109,7 @@ func TestSendRequestUsesHeaders(t *testing.T) {
 
 	expected := client.GetRequestArg()
 	assertHeadersMatch(t, headers, expected.Header)
-	testtools.AssertErrorIsNil(t, err)
+	assert.Nil(t, err)
 }
 
 func TestSendRequestUsesNoHeadersIfNotProvided(t *testing.T) {
@@ -118,7 +121,7 @@ func TestSendRequestUsesNoHeadersIfNotProvided(t *testing.T) {
 	if len(expected.Header) > 0 {
 		t.Errorf("Headers should be empty, found %v", expected.Header)
 	}
-	testtools.AssertErrorIsNil(t, err)
+	assert.Nil(t, err)
 }
 
 func TestSendRequestReturnsErrorOnErrorRequestOptions(t *testing.T) {
@@ -127,7 +130,7 @@ func TestSendRequestReturnsErrorOnErrorRequestOptions(t *testing.T) {
 
 	_, err := sender.Send(options)
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestSendRequestReturnsErrorOnClientError(t *testing.T) {
@@ -136,7 +139,7 @@ func TestSendRequestReturnsErrorOnClientError(t *testing.T) {
 
 	_, err := sender.Send(options)
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestSendRequestReturnsErrorWhenStatusNotExpected(t *testing.T) {
@@ -145,7 +148,7 @@ func TestSendRequestReturnsErrorWhenStatusNotExpected(t *testing.T) {
 
 	_, err := sender.Send(options)
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestSendRequestReturnsErrorOnResponseBodyError(t *testing.T) {
@@ -154,7 +157,7 @@ func TestSendRequestReturnsErrorOnResponseBodyError(t *testing.T) {
 
 	_, err := sender.Send(options)
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestSendRequestReturnsResponseBody(t *testing.T) {
@@ -162,8 +165,8 @@ func TestSendRequestReturnsResponseBody(t *testing.T) {
 
 	body, err := sender.Send(options)
 
-	testtools.AssertEqual(t, string(*body), string(defaultResponseBody()))
-	testtools.AssertErrorIsNil(t, err)
+	assert.Equal(t, string(*body), string(defaultResponseBody()))
+	assert.Nil(t, err)
 }
 
 func readBodyFromRequest(t *testing.T, request *http.Request) []byte {

--- a/internal/playlist/concurrent_playlist_service_test.go
+++ b/internal/playlist/concurrent_playlist_service_test.go
@@ -8,6 +8,8 @@ import (
 	"festwrap/internal/setlist"
 	"festwrap/internal/song"
 	"festwrap/internal/testtools"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func defaultContext() context.Context {
@@ -115,8 +117,8 @@ func TestCreatePlaylistRepositoryCalledWithArgs(t *testing.T) {
 
 	actual := playlistRepository.GetCreatePlaylistArgs()
 	expected := CreatePlaylistArgs{Context: defaultContext(), Playlist: defaultPlaylist()}
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, actual, expected)
+	assert.Nil(t, err)
+	assert.Equal(t, actual, expected)
 }
 
 func TestCreatePlaylistReturnsPlaylistIdOnSuccess(t *testing.T) {
@@ -127,8 +129,8 @@ func TestCreatePlaylistReturnsPlaylistIdOnSuccess(t *testing.T) {
 
 	actual, err := service.CreatePlaylist(defaultContext(), defaultPlaylist())
 
-	testtools.AssertEqual(t, actual, expected)
-	testtools.AssertErrorIsNil(t, err)
+	assert.Equal(t, actual, expected)
+	assert.Nil(t, err)
 }
 
 func TestCreatePlaylistReturnsErrorIfRepositoryErrors(t *testing.T) {
@@ -138,7 +140,7 @@ func TestCreatePlaylistReturnsErrorIfRepositoryErrors(t *testing.T) {
 
 	_, err := service.CreatePlaylist(defaultContext(), defaultPlaylist())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestAddSetlistSetlistRepositoryCalledWithArgs(t *testing.T) {
@@ -153,8 +155,8 @@ func TestAddSetlistSetlistRepositoryCalledWithArgs(t *testing.T) {
 
 	actual := setlistRepository.GetGetSetlistArgs()
 	expected := setlist.GetSetlistArgs{Artist: artist, MinSongs: minSongs}
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, actual, expected)
+	assert.Nil(t, err)
+	assert.Equal(t, actual, expected)
 }
 
 func TestAddSetlistReturnsErrorOnSetlistRepositoryError(t *testing.T) {
@@ -165,7 +167,7 @@ func TestAddSetlistReturnsErrorOnSetlistRepositoryError(t *testing.T) {
 
 	err := service.AddSetlist(defaultContext(), defaultPlaylistId(), defaultArtist())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestAddSetlistSongRepositoryCalledWithSetlistSongs(t *testing.T) {
@@ -176,7 +178,7 @@ func TestAddSetlistSongRepositoryCalledWithSetlistSongs(t *testing.T) {
 
 	actual := songRepository.GetGetSongArgs()
 	expected := defaultGetSongArgs()
-	testtools.AssertErrorIsNil(t, err)
+	assert.Nil(t, err)
 	if !testtools.HaveSameElements(actual, expected) {
 		t.Errorf("Expected called songs %v, found %v", expected, actual)
 	}
@@ -191,8 +193,8 @@ func TestAddSetlistAddsSongsFetched(t *testing.T) {
 
 	actual := playlistRepository.GetAddSongArgs()
 	expected := defaultAddSongsArgs()
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, actual, expected)
+	assert.Nil(t, err)
+	assert.Equal(t, actual, expected)
 }
 
 func TestAddSetlistAddsOnlySongsFetchedWithoutError(t *testing.T) {
@@ -204,8 +206,8 @@ func TestAddSetlistAddsOnlySongsFetchedWithoutError(t *testing.T) {
 
 	actual := playlistRepository.GetAddSongArgs()
 	expected := addSongsArgsWithErrors()
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, actual, expected)
+	assert.Nil(t, err)
+	assert.Equal(t, actual, expected)
 }
 
 func TestAddSetlistSetlistRaisesErrorIfSetlistEmpty(t *testing.T) {
@@ -215,7 +217,7 @@ func TestAddSetlistSetlistRaisesErrorIfSetlistEmpty(t *testing.T) {
 
 	err := service.AddSetlist(defaultContext(), defaultPlaylistId(), defaultArtist())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestAddSetlistSetlistRaisesErrorIfNoSongsFound(t *testing.T) {
@@ -225,5 +227,5 @@ func TestAddSetlistSetlistRaisesErrorIfNoSongsFound(t *testing.T) {
 
 	err := service.AddSetlist(defaultContext(), defaultPlaylistId(), defaultArtist())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }

--- a/internal/playlist/spotify/spotify_playlist_repository_test.go
+++ b/internal/playlist/spotify/spotify_playlist_repository_test.go
@@ -12,6 +12,8 @@ import (
 	"festwrap/internal/serialization"
 	"festwrap/internal/song"
 	"festwrap/internal/testtools"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func fakeSender() *httpsender.FakeHTTPSender {
@@ -216,7 +218,7 @@ func TestAddSongsReturnsErrorWhenNoSongsProvided(t *testing.T) {
 
 	err := repository.AddSongs(defaultContext(), defaultPlaylistId(), []song.Song{})
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestAddSongsSerializesInputSongs(t *testing.T) {
@@ -226,7 +228,7 @@ func TestAddSongsSerializesInputSongs(t *testing.T) {
 
 	expected := SpotifySongs{Uris: []string{"uri1", "uri2"}}
 	actual := repository.GetSongSerializer().(*serialization.FakeSerializer[SpotifySongs]).GetArgs()
-	testtools.AssertEqual(t, actual, expected)
+	assert.Equal(t, actual, expected)
 }
 
 func TestAddSongsReturnsErrorOnNonSerializationError(t *testing.T) {
@@ -237,7 +239,7 @@ func TestAddSongsReturnsErrorOnNonSerializationError(t *testing.T) {
 
 	err := repository.AddSongs(defaultContext(), defaultPlaylistId(), defaultSongs())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestAddSongsSendsRequestUsingProperOptions(t *testing.T) {
@@ -246,7 +248,7 @@ func TestAddSongsSendsRequestUsingProperOptions(t *testing.T) {
 	repository.AddSongs(defaultContext(), defaultPlaylistId(), defaultSongs())
 
 	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
-	testtools.AssertEqual(t, actual, expectedAddSongsHttpOptions())
+	assert.Equal(t, actual, expectedAddSongsHttpOptions())
 }
 
 func TestAddSongsReturnsErrorOnSendError(t *testing.T) {
@@ -255,7 +257,7 @@ func TestAddSongsReturnsErrorOnSendError(t *testing.T) {
 
 	err := repository.AddSongs(defaultContext(), defaultPlaylistId(), defaultSongs())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestAddSongsSerializesInputPlaylist(t *testing.T) {
@@ -265,7 +267,7 @@ func TestAddSongsSerializesInputPlaylist(t *testing.T) {
 
 	expected := SpotifyPlaylist{Name: "my-playlist", Description: "some playlist", IsPublic: false}
 	actual := repository.GetPlaylistCreateSerializer().(*serialization.FakeSerializer[SpotifyPlaylist]).GetArgs()
-	testtools.AssertEqual(t, actual, expected)
+	assert.Equal(t, actual, expected)
 }
 
 func TestCreatePlaylistReturnsErrorOnPlaylistSerializationError(t *testing.T) {
@@ -276,7 +278,7 @@ func TestCreatePlaylistReturnsErrorOnPlaylistSerializationError(t *testing.T) {
 
 	_, err := repository.CreatePlaylist(defaultContext(), defaultPlaylist())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestCreatePlaylistSendsCreateRequestWithOptions(t *testing.T) {
@@ -285,7 +287,7 @@ func TestCreatePlaylistSendsCreateRequestWithOptions(t *testing.T) {
 	repository.CreatePlaylist(defaultContext(), defaultPlaylist())
 
 	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
-	testtools.AssertEqual(t, actual, expectedCreatePlaylistHttpOptions())
+	assert.Equal(t, actual, expectedCreatePlaylistHttpOptions())
 }
 
 func TestCreatePlaylistReturnsErrorOnDeserializationError(t *testing.T) {
@@ -296,7 +298,7 @@ func TestCreatePlaylistReturnsErrorOnDeserializationError(t *testing.T) {
 
 	_, err := repository.CreatePlaylist(defaultContext(), defaultPlaylist())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestCreatePlaylistReturnsIdFromDeserializedResponse(t *testing.T) {
@@ -308,7 +310,7 @@ func TestCreatePlaylistReturnsIdFromDeserializedResponse(t *testing.T) {
 
 	actual, _ := repository.CreatePlaylist(defaultContext(), defaultPlaylist())
 
-	testtools.AssertEqual(t, actual, deserialized.Id)
+	assert.Equal(t, actual, deserialized.Id)
 }
 
 func TestCreatePlaylistReturnsErrorOnSendError(t *testing.T) {
@@ -317,7 +319,7 @@ func TestCreatePlaylistReturnsErrorOnSendError(t *testing.T) {
 
 	_, err := repository.CreatePlaylist(defaultContext(), defaultPlaylist())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestSearchPlaylistSendsCreateRequestWithOptions(t *testing.T) {
@@ -326,7 +328,7 @@ func TestSearchPlaylistSendsCreateRequestWithOptions(t *testing.T) {
 	repository.SearchPlaylist(defaultContext(), defaultPlaylistName(), defaultSearchPlaylistLimit())
 
 	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
-	testtools.AssertEqual(t, actual, expectedSearchPlaylistHttpOptions())
+	assert.Equal(t, actual, expectedSearchPlaylistHttpOptions())
 }
 
 func TestSearchPlaylistReturnsErrorOnSendError(t *testing.T) {
@@ -335,7 +337,7 @@ func TestSearchPlaylistReturnsErrorOnSendError(t *testing.T) {
 
 	_, err := repository.SearchPlaylist(defaultContext(), defaultPlaylistName(), defaultSearchPlaylistLimit())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestSearchPlaylistReturnsErrorOnDeserializationError(t *testing.T) {
@@ -346,7 +348,7 @@ func TestSearchPlaylistReturnsErrorOnDeserializationError(t *testing.T) {
 
 	_, err := repository.SearchPlaylist(defaultContext(), defaultPlaylistName(), defaultSearchPlaylistLimit())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestSearchPlaylistReturnsDeserializedContent(t *testing.T) {
@@ -354,8 +356,8 @@ func TestSearchPlaylistReturnsDeserializedContent(t *testing.T) {
 
 	actual, err := repository.SearchPlaylist(defaultContext(), defaultPlaylistName(), defaultSearchPlaylistLimit())
 
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, actual, defaultSearchedFilteredPlaylists())
+	assert.Nil(t, err)
+	assert.Equal(t, actual, defaultSearchedFilteredPlaylists())
 }
 
 func TestAddSongsPlaylistSendsOptionsUsingSerializerIntegration(t *testing.T) {
@@ -368,7 +370,7 @@ func TestAddSongsPlaylistSendsOptionsUsingSerializerIntegration(t *testing.T) {
 	repository.AddSongs(defaultContext(), defaultPlaylistId(), defaultSongs())
 
 	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
-	testtools.AssertEqual(t, actual, expectedAddSongsHttpOptions())
+	assert.Equal(t, actual, expectedAddSongsHttpOptions())
 }
 
 func TestCreatePlaylistSendsOptionsUsingSerializerIntegration(t *testing.T) {
@@ -381,7 +383,7 @@ func TestCreatePlaylistSendsOptionsUsingSerializerIntegration(t *testing.T) {
 	repository.CreatePlaylist(defaultContext(), defaultPlaylist())
 
 	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
-	testtools.AssertEqual(t, actual, expectedCreatePlaylistHttpOptions())
+	assert.Equal(t, actual, expectedCreatePlaylistHttpOptions())
 }
 
 func TestCreatePlaylistReturnsResultsUsingDeserializerIntegration(t *testing.T) {
@@ -397,8 +399,8 @@ func TestCreatePlaylistReturnsResultsUsingDeserializerIntegration(t *testing.T) 
 
 	id, err := repository.CreatePlaylist(defaultContext(), defaultPlaylist())
 
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, id, defaultPlaylistId())
+	assert.Nil(t, err)
+	assert.Equal(t, id, defaultPlaylistId())
 }
 
 func TestSearchPlaylistReturnsResultsUsingDeserializerIntegration(t *testing.T) {
@@ -414,8 +416,8 @@ func TestSearchPlaylistReturnsResultsUsingDeserializerIntegration(t *testing.T) 
 
 	actual, err := repository.SearchPlaylist(defaultContext(), defaultPlaylistName(), defaultSearchPlaylistLimit())
 
-	testtools.AssertEqual(t, actual, defaultSearchedFilteredPlaylists())
-	testtools.AssertErrorIsNil(t, err)
+	assert.Equal(t, actual, defaultSearchedFilteredPlaylists())
+	assert.Nil(t, err)
 }
 
 func TestRepositoryMethodsReturnErrorWhenInvalidToken(t *testing.T) {
@@ -444,13 +446,13 @@ func TestRepositoryMethodsReturnErrorWhenInvalidToken(t *testing.T) {
 			repository.SetTokenKey(test.repositoryTokenKey)
 
 			err := repository.AddSongs(ctx, defaultPlaylistId(), defaultSongs())
-			testtools.AssertErrorIsNotNil(t, err)
+			assert.NotNil(t, err)
 
 			_, err = repository.CreatePlaylist(ctx, defaultPlaylist())
-			testtools.AssertErrorIsNotNil(t, err)
+			assert.NotNil(t, err)
 
 			_, err = repository.SearchPlaylist(ctx, defaultPlaylistName(), defaultSearchPlaylistLimit())
-			testtools.AssertErrorIsNotNil(t, err)
+			assert.NotNil(t, err)
 		})
 	}
 }
@@ -481,10 +483,10 @@ func TestRepositoryMethodsReturnErrorWhenInvalidUserId(t *testing.T) {
 			repository.SetUserIdKey(test.repositoryUserIdKey)
 
 			_, err := repository.SearchPlaylist(ctx, defaultPlaylistName(), defaultSearchPlaylistLimit())
-			testtools.AssertErrorIsNotNil(t, err)
+			assert.NotNil(t, err)
 
 			_, err = repository.CreatePlaylist(ctx, defaultPlaylist())
-			testtools.AssertErrorIsNotNil(t, err)
+			assert.NotNil(t, err)
 		})
 	}
 }

--- a/internal/serialization/json_deserializer_test.go
+++ b/internal/serialization/json_deserializer_test.go
@@ -1,8 +1,9 @@
 package serialization
 
 import (
-	"festwrap/internal/testtools"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJsonDeserializerProducesExpectedResult(t *testing.T) {
@@ -12,8 +13,8 @@ func TestJsonDeserializerProducesExpectedResult(t *testing.T) {
 	err := deserializer.Deserialize(serializableObjectBytes(), &actual)
 
 	expected := serializableObject()
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, actual, expected)
+	assert.Nil(t, err)
+	assert.Equal(t, actual, expected)
 }
 
 func TestJsonDeserializerReturnsErrorOnNonJsonInput(t *testing.T) {
@@ -23,5 +24,5 @@ func TestJsonDeserializerReturnsErrorOnNonJsonInput(t *testing.T) {
 	nonJsonBytes := []byte(`"something": "something"`)
 	err := deserializer.Deserialize(nonJsonBytes, &object)
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }

--- a/internal/serialization/json_serializer_test.go
+++ b/internal/serialization/json_serializer_test.go
@@ -1,8 +1,9 @@
 package serialization
 
 import (
-	"festwrap/internal/testtools"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBaseSerializerReturnsExpectedOutput(t *testing.T) {
@@ -12,8 +13,8 @@ func TestBaseSerializerReturnsExpectedOutput(t *testing.T) {
 	actual, err := serializer.Serialize(object)
 
 	expected := serializableObjectBytes()
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, actual, expected)
+	assert.Nil(t, err)
+	assert.Equal(t, actual, expected)
 }
 
 func TestBaseSerializerReturnsErrorOnNonSerializableObject(t *testing.T) {
@@ -22,5 +23,5 @@ func TestBaseSerializerReturnsErrorOnNonSerializableObject(t *testing.T) {
 	object := nonSerializableObject()
 	_, err := serializer.Serialize(object)
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }

--- a/internal/setlist/setlistfm/setlistfm_setlist_repository_test.go
+++ b/internal/setlist/setlistfm/setlistfm_setlist_repository_test.go
@@ -8,6 +8,8 @@ import (
 	"festwrap/internal/testtools"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func defaultArtist() string {
@@ -111,7 +113,7 @@ func TestGetSetlistSenderCalledWithProperOptions(t *testing.T) {
 
 	repository.GetSetlist(defaultArtist(), defaultMinSongs())
 
-	testtools.AssertEqual(t, sender.GetSendArgs(), expectedHttpOptions())
+	assert.Equal(t, sender.GetSendArgs(), expectedHttpOptions())
 }
 
 func TestGetSetlistReturnsErrorOnSenderError(t *testing.T) {
@@ -121,7 +123,7 @@ func TestGetSetlistReturnsErrorOnSenderError(t *testing.T) {
 
 	_, err := repository.GetSetlist(defaultArtist(), defaultMinSongs())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestGetSetlistDeserializerCalledWithSenderResponse(t *testing.T) {
@@ -131,7 +133,7 @@ func TestGetSetlistDeserializerCalledWithSenderResponse(t *testing.T) {
 
 	repository.GetSetlist(defaultArtist(), defaultMinSongs())
 
-	testtools.AssertEqual(t, deserializer.GetArgs(), senderResponse())
+	assert.Equal(t, deserializer.GetArgs(), senderResponse())
 }
 
 func TestGetSetlistReturnsErrorOnDeserializationError(t *testing.T) {
@@ -142,7 +144,7 @@ func TestGetSetlistReturnsErrorOnDeserializationError(t *testing.T) {
 
 	_, err := repository.GetSetlist(defaultArtist(), defaultMinSongs())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestGetSetlistReturnsErrorIfNoSetlistFound(t *testing.T) {
@@ -154,7 +156,7 @@ func TestGetSetlistReturnsErrorIfNoSetlistFound(t *testing.T) {
 
 	_, err := repository.GetSetlist(defaultArtist(), defaultMinSongs())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestGetSetlistReturnsSetlistFromDeserializedResponse(t *testing.T) {
@@ -162,7 +164,7 @@ func TestGetSetlistReturnsSetlistFromDeserializedResponse(t *testing.T) {
 
 	actual, _ := repository.GetSetlist(defaultArtist(), defaultMinSongs())
 
-	testtools.AssertEqual(t, actual, expectedSetlist())
+	assert.Equal(t, actual, expectedSetlist())
 }
 
 func TestGetSetlistRetrievesErrorWhenMinSongsNotReached(t *testing.T) {
@@ -170,7 +172,7 @@ func TestGetSetlistRetrievesErrorWhenMinSongsNotReached(t *testing.T) {
 
 	_, err := repository.GetSetlist(defaultArtist(), 50)
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestGetSetlistRetrievesSetlistFromResponseIntegration(t *testing.T) {
@@ -183,6 +185,6 @@ func TestGetSetlistRetrievesSetlistFromResponseIntegration(t *testing.T) {
 
 	actual, err := repository.GetSetlist(defaultArtist(), defaultMinSongs())
 
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, actual, integrationSetlist())
+	assert.Nil(t, err)
+	assert.Equal(t, actual, integrationSetlist())
 }

--- a/internal/song/spotify/spotify_song_repository_test.go
+++ b/internal/song/spotify/spotify_song_repository_test.go
@@ -8,6 +8,8 @@ import (
 	"festwrap/internal/testtools"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func defaultArtist() string {
@@ -74,8 +76,8 @@ func TestGetSongSendsRequestWithProperOptions(t *testing.T) {
 
 	_, err := repository.GetSong(defaultArtist(), defaultTitle())
 
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, sender.GetSendArgs(), expectedHttpOptions())
+	assert.Nil(t, err)
+	assert.Equal(t, sender.GetSendArgs(), expectedHttpOptions())
 }
 
 func TestGetSongReturnsErrorOnSendError(t *testing.T) {
@@ -85,7 +87,7 @@ func TestGetSongReturnsErrorOnSendError(t *testing.T) {
 
 	_, err := repository.GetSong(defaultArtist(), defaultTitle())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestGetSongCallsDeserializeWithSendResponseBody(t *testing.T) {
@@ -95,8 +97,8 @@ func TestGetSongCallsDeserializeWithSendResponseBody(t *testing.T) {
 
 	_, err := repository.GetSong(defaultArtist(), defaultTitle())
 
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, deserializer.GetArgs(), defaultResponse())
+	assert.Nil(t, err)
+	assert.Equal(t, deserializer.GetArgs(), defaultResponse())
 }
 
 func TestGetSongReturnsErrorOnResponseBodyDeserializationError(t *testing.T) {
@@ -107,7 +109,7 @@ func TestGetSongReturnsErrorOnResponseBodyDeserializationError(t *testing.T) {
 
 	_, err := repository.GetSong(defaultArtist(), defaultTitle())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestGetSongReturnsErrorIfNoSongsFound(t *testing.T) {
@@ -119,7 +121,7 @@ func TestGetSongReturnsErrorIfNoSongsFound(t *testing.T) {
 
 	_, err := repository.GetSong(defaultArtist(), defaultTitle())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestGetSongReturnsFirstSongFound(t *testing.T) {
@@ -128,8 +130,8 @@ func TestGetSongReturnsFirstSongFound(t *testing.T) {
 	actual, err := repository.GetSong(defaultArtist(), defaultTitle())
 
 	expected := song.NewSong(defaultDeserializedResponse().Tracks.Songs[0].Uri)
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, *actual, expected)
+	assert.Nil(t, err)
+	assert.Equal(t, *actual, expected)
 }
 
 func TestGetSongReturnsFirstSongFoundIntegration(t *testing.T) {
@@ -143,6 +145,6 @@ func TestGetSongReturnsFirstSongFoundIntegration(t *testing.T) {
 	actual, err := repository.GetSong(defaultArtist(), defaultTitle())
 
 	expected := song.NewSong("spotify:track:4rH1kFLYW0b28UNRyn7dK3")
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, *actual, expected)
+	assert.Nil(t, err)
+	assert.Equal(t, *actual, expected)
 }

--- a/internal/testtools/check.go
+++ b/internal/testtools/check.go
@@ -1,46 +1,9 @@
 package testtools
 
-import (
-	"reflect"
-	"testing"
-)
-
 func HaveSameElements[T comparable](set1 []T, set2 []T) bool {
 	c1 := valueCounts(set1)
 	c2 := valueCounts(set2)
 	return areCountsEqual(c1, c2)
-}
-
-func AssertIsNil(t *testing.T, value interface{}) {
-	t.Helper()
-
-	if value != nil {
-		t.Errorf("Value should be nil, but found %v", value)
-	}
-}
-
-func AssertErrorIsNil(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Errorf("Error should be nil, but found %v", err)
-	}
-}
-
-func AssertErrorIsNotNil(t *testing.T, err error) {
-	t.Helper()
-
-	if err == nil {
-		t.Errorf("Expected error, found nil")
-	}
-}
-
-func AssertEqual(t *testing.T, actual interface{}, expected interface{}) {
-	t.Helper()
-
-	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("Expected %v, found %v", expected, actual)
-	}
 }
 
 func valueCounts[T comparable](set []T) map[T]int {

--- a/internal/user/spotify/spotify_user_repository_test.go
+++ b/internal/user/spotify/spotify_user_repository_test.go
@@ -8,6 +8,8 @@ import (
 	"festwrap/internal/serialization"
 	"festwrap/internal/testtools"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func defaultTokenKey() types.ContextKey {
@@ -83,7 +85,7 @@ func TestRepositoryMethodsReturnErrorWhenInvalidToken(t *testing.T) {
 			repository.SetTokenKey(test.repositoryTokenKey)
 
 			_, err := repository.GetCurrentUserId(ctx)
-			testtools.AssertErrorIsNotNil(t, err)
+			assert.NotNil(t, err)
 		})
 	}
 }
@@ -94,8 +96,8 @@ func TestGetCurrentUserIdSendsRequestWithProperOptions(t *testing.T) {
 
 	_, err := repository.GetCurrentUserId(defaultContext())
 
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, sender.GetSendArgs(), expectedHttpOptions())
+	assert.Nil(t, err)
+	assert.Equal(t, sender.GetSendArgs(), expectedHttpOptions())
 }
 
 func TestGetCurrentUserReturnsErrorOnSendError(t *testing.T) {
@@ -105,7 +107,7 @@ func TestGetCurrentUserReturnsErrorOnSendError(t *testing.T) {
 
 	_, err := repository.GetCurrentUserId(defaultContext())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestGetCurrentUserCallsDeserializeWithSendResponseBody(t *testing.T) {
@@ -113,9 +115,9 @@ func TestGetCurrentUserCallsDeserializeWithSendResponseBody(t *testing.T) {
 
 	_, err := repository.GetCurrentUserId(defaultContext())
 
-	testtools.AssertErrorIsNil(t, err)
+	assert.Nil(t, err)
 	deserializer := repository.GetDeserializer().(*serialization.FakeDeserializer[spotifyUserResponse])
-	testtools.AssertEqual(t, deserializer.GetArgs(), defaultResponse())
+	assert.Equal(t, deserializer.GetArgs(), defaultResponse())
 }
 
 func TestGetCurrentUserReturnsErrorOnResponseBodyDeserializationError(t *testing.T) {
@@ -126,7 +128,7 @@ func TestGetCurrentUserReturnsErrorOnResponseBodyDeserializationError(t *testing
 
 	_, err := repository.GetCurrentUserId(defaultContext())
 
-	testtools.AssertErrorIsNotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestGetCurrentUserReturnsFirstSongFoundIntegration(t *testing.T) {
@@ -138,6 +140,6 @@ func TestGetCurrentUserReturnsFirstSongFoundIntegration(t *testing.T) {
 	actual, err := repository.GetCurrentUserId(defaultContext())
 
 	expected := "my_id"
-	testtools.AssertErrorIsNil(t, err)
-	testtools.AssertEqual(t, actual, expected)
+	assert.Nil(t, err)
+	assert.Equal(t, actual, expected)
 }


### PR DESCRIPTION
# Description

Using `testify` dependency for asserts in tests. I initially tried to use a minimal amount of dependencies, but given that test code is becoming larger and more difficult to maintain, I decided to use a third party library.

This PR replaces the custom asserts by the `testify` ones.

# Next steps

We will create a separate PR to simplify fake objects by using `testify` mock.