### PR TITLE
feat: FW-66 Implement add songs endpoint

### DIFF
--- a/cmd/handler/playlist/playlist_update.go
+++ b/cmd/handler/playlist/playlist_update.go
@@ -1,0 +1,9 @@
+package playlist
+
+type updateArtists struct {
+	Name string `json:"name"`
+}
+
+type playlistUpdate struct {
+	Artists []updateArtists `json:"artists"`
+}

--- a/cmd/handler/playlist/update_playlist.go
+++ b/cmd/handler/playlist/update_playlist.go
@@ -1,0 +1,86 @@
+package playlist
+
+import (
+	"festwrap/internal/logging"
+	"festwrap/internal/playlist"
+	"festwrap/internal/serialization"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type UpdatePlaylistHandler struct {
+	playlistService playlist.PlaylistService
+	logger          logging.Logger
+	deserializer    serialization.Deserializer[playlistUpdate]
+	maxArtists      int
+	playlistIdPath  string
+}
+
+func NewUpdatePlaylistHandler(playlistService playlist.PlaylistService, logger logging.Logger) UpdatePlaylistHandler {
+	return UpdatePlaylistHandler{
+		playlistService: playlistService,
+		logger:          logger,
+		deserializer:    serialization.NewJsonDeserializer[playlistUpdate](),
+		maxArtists:      5,
+		playlistIdPath:  "playlistId",
+	}
+}
+
+func (h *UpdatePlaylistHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	playlistId := r.PathValue(h.playlistIdPath)
+	if playlistId == "" {
+		message := "validation error: playlist id was not provided"
+		h.logger.Warn(message)
+		http.Error(w, message, http.StatusBadRequest)
+		return
+	}
+
+	defer r.Body.Close()
+	requestBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		message := "validation error: could not read body"
+		h.logger.Warn(message)
+		http.Error(w, message, http.StatusBadRequest)
+		return
+	}
+
+	var update playlistUpdate
+	h.deserializer.Deserialize(requestBody, &update)
+	if len(update.Artists) > h.maxArtists {
+		message := fmt.Sprintf("validation error: cannot update playlist with more than %d artists", h.maxArtists)
+		h.logger.Warn(message)
+		http.Error(w, message, http.StatusBadRequest)
+		return
+	}
+
+	errors := 0
+	for _, artist := range update.Artists {
+		err := h.playlistService.AddSetlist(r.Context(), playlistId, artist.Name)
+		if err != nil {
+			h.logger.Warn(fmt.Sprintf("could not add songs for %s to playlist %s: %v", artist.Name, playlistId, err))
+			errors += 1
+		}
+	}
+
+	statusCode := http.StatusCreated
+	if errors > 0 && errors < len(update.Artists) {
+		statusCode = http.StatusMultiStatus
+	} else if errors > 0 {
+		statusCode = http.StatusInternalServerError
+	}
+
+	w.WriteHeader(statusCode)
+}
+
+func (h *UpdatePlaylistHandler) SetDeserializer(deserializer serialization.Deserializer[playlistUpdate]) {
+	h.deserializer = deserializer
+}
+
+func (h *UpdatePlaylistHandler) SetPlaylistService(service playlist.PlaylistService) {
+	h.playlistService = service
+}
+
+func (h *UpdatePlaylistHandler) SetMaxArtists(limit int) {
+	h.maxArtists = limit
+}

--- a/cmd/handler/playlist/update_playlist_test.go
+++ b/cmd/handler/playlist/update_playlist_test.go
@@ -44,7 +44,7 @@ func partialErrorPlaylistService() *mocks.PlaylistServiceMock {
 
 func buildRequest(t *testing.T, playlistId string, body []byte) *http.Request {
 	t.Helper()
-	requestUrl, err := url.Parse("https://example.com/playlist/{playlistId}/update")
+	requestUrl, err := url.Parse("https://example.com/playlist/{playlistId}")
 	if err != nil {
 		t.Errorf("Could not create request: %v", err.Error())
 	}

--- a/cmd/handler/playlist/update_playlist_test.go
+++ b/cmd/handler/playlist/update_playlist_test.go
@@ -1,0 +1,147 @@
+package playlist
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"festwrap/internal/logging"
+	mocks "festwrap/internal/playlist/mocks"
+	"festwrap/internal/serialization"
+	"festwrap/internal/testtools"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func defaultPlaylistId() string {
+	return "myId"
+}
+
+func defaultUpdateBody() []byte {
+	return []byte(`{artists:[{"name":"Silverstein",{"name":"Chinese Football"}]}`)
+}
+
+func defaultDeserializedBody() playlistUpdate {
+	return playlistUpdate{Artists: []updateArtists{{Name: "Silverstein"}, {"Chinese Football"}}}
+}
+
+func alwaysErrorPlaylistService() *mocks.PlaylistServiceMock {
+	playlistService := &mocks.PlaylistServiceMock{}
+	playlistService.On("AddSetlist", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("test error"))
+	return playlistService
+}
+
+func partialErrorPlaylistService() *mocks.PlaylistServiceMock {
+	playlistService := &mocks.PlaylistServiceMock{}
+	playlistService.On("AddSetlist", mock.Anything, defaultPlaylistId(), "Silverstein").Return(errors.New("test error"))
+	playlistService.On("AddSetlist", mock.Anything, defaultPlaylistId(), mock.Anything).Return(nil)
+	return playlistService
+}
+
+func buildRequest(t *testing.T, playlistId string, body []byte) *http.Request {
+	t.Helper()
+	requestUrl, err := url.Parse("https://example.com/playlist/{playlistId}/update")
+	if err != nil {
+		t.Errorf("Could not create request: %v", err.Error())
+	}
+
+	request := httptest.NewRequest("GET", requestUrl.String(), bytes.NewBuffer(body))
+	if playlistId != "" {
+		request.SetPathValue("playlistId", playlistId)
+	}
+	return request
+}
+
+func updatePlaylistHandler(t *testing.T) UpdatePlaylistHandler {
+	t.Helper()
+	deserializer := serialization.FakeDeserializer[playlistUpdate]{}
+	deserializer.SetResponse(defaultDeserializedBody())
+
+	playlistService := mocks.NewPlaylistServiceMock()
+	playlistService.On("AddSetlist", mock.Anything, defaultPlaylistId(), mock.Anything).Return(nil)
+
+	handler := NewUpdatePlaylistHandler(&playlistService, logging.NoopLogger{})
+	handler.SetDeserializer(&deserializer)
+	return handler
+}
+
+func TestBadRequestIfPlaylistIdNotProvided(t *testing.T) {
+	request := buildRequest(t, "", defaultUpdateBody())
+	writer := httptest.NewRecorder()
+	handler := updatePlaylistHandler(t)
+
+	handler.ServeHTTP(writer, request)
+
+	assert.Equal(t, writer.Code, http.StatusBadRequest)
+}
+
+func TestBadRequestOnInvalidBody(t *testing.T) {
+	invalidBody := []byte(`{"someInvalidBody":"value"}`)
+	request := buildRequest(t, "", invalidBody)
+	writer := httptest.NewRecorder()
+	handler := updatePlaylistHandler(t)
+
+	handler.ServeHTTP(writer, request)
+
+	assert.Equal(t, writer.Code, http.StatusBadRequest)
+}
+
+func TestBadRequestOnMoreArtistsThanAllowed(t *testing.T) {
+	request := buildRequest(t, "", defaultUpdateBody())
+	writer := httptest.NewRecorder()
+	handler := updatePlaylistHandler(t)
+	handler.SetMaxArtists(1)
+
+	handler.ServeHTTP(writer, request)
+
+	assert.Equal(t, writer.Code, http.StatusBadRequest)
+}
+
+func TestServerStatusOnNoErrors(t *testing.T) {
+	request := buildRequest(t, defaultPlaylistId(), defaultUpdateBody())
+	writer := httptest.NewRecorder()
+	handler := updatePlaylistHandler(t)
+
+	handler.ServeHTTP(writer, request)
+
+	assert.Equal(t, http.StatusCreated, writer.Code)
+}
+
+func TestServerErrorReturnedWhenAllArtistsFailed(t *testing.T) {
+	request := buildRequest(t, defaultPlaylistId(), defaultUpdateBody())
+	writer := httptest.NewRecorder()
+	handler := updatePlaylistHandler(t)
+	handler.SetPlaylistService(alwaysErrorPlaylistService())
+
+	handler.ServeHTTP(writer, request)
+
+	assert.Equal(t, http.StatusInternalServerError, writer.Code)
+}
+
+func TestServerStatusOnPartialErrors(t *testing.T) {
+	request := buildRequest(t, defaultPlaylistId(), defaultUpdateBody())
+	writer := httptest.NewRecorder()
+	handler := updatePlaylistHandler(t)
+	handler.SetPlaylistService(partialErrorPlaylistService())
+
+	handler.ServeHTTP(writer, request)
+
+	assert.Equal(t, http.StatusMultiStatus, writer.Code)
+}
+
+func TestHandlerUsesDeserializedBodyIntegration(t *testing.T) {
+	testtools.SkipOnShortRun(t)
+
+	request := buildRequest(t, defaultPlaylistId(), defaultUpdateBody())
+	writer := httptest.NewRecorder()
+	handler := updatePlaylistHandler(t)
+	handler.SetDeserializer(serialization.NewJsonDeserializer[playlistUpdate]())
+
+	handler.ServeHTTP(writer, request)
+
+	assert.Equal(t, http.StatusCreated, writer.Code)
+}

--- a/cmd/scripts/add_songs_to_playlist.go
+++ b/cmd/scripts/add_songs_to_playlist.go
@@ -30,16 +30,12 @@ func main() {
 
 	fmt.Printf("Adding latest setlist songs for %s into Spotify playlist with id %s \n", *artist, *playlistId)
 
-	setlistRepository := setlistfm.NewSetlistFMSetlistRepository(
-		*setlistfmApiKey,
-		&httpSender,
-	)
-	songRepository := spotifySong.NewSpotifySongRepository(
-		*spotifyAccessToken,
-		&httpSender,
-	)
-
 	var tokenKey types.ContextKey = "token"
+
+	setlistRepository := setlistfm.NewSetlistFMSetlistRepository(*setlistfmApiKey, &httpSender)
+	songRepository := spotifySong.NewSpotifySongRepository(&httpSender)
+	songRepository.SetTokenKey(tokenKey)
+
 	playlistRepository := spotifyPlaylist.NewSpotifyPlaylistRepository(&httpSender)
 	playlistRepository.SetTokenKey(tokenKey)
 	playlistService := playlist.NewConcurrentPlaylistService(

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require github.com/stretchr/testify v1.10.0
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/playlist/concurrent_playlist_service.go
+++ b/internal/playlist/concurrent_playlist_service.go
@@ -45,7 +45,7 @@ func (s *ConcurrentPlaylistService) AddSetlist(ctx context.Context, playlistId s
 
 	ch := make(chan FetchSongResult)
 	for _, song := range setlist.GetSongs() {
-		go s.fetchSong(artist, song, ch)
+		go s.fetchSong(ctx, artist, song, ch)
 	}
 
 	songs := []song.Song{}
@@ -73,7 +73,12 @@ func (s *ConcurrentPlaylistService) SetMinSongs(minSongs int) {
 	s.minSongs = minSongs
 }
 
-func (s *ConcurrentPlaylistService) fetchSong(artist string, song setlist.Song, ch chan<- FetchSongResult) {
-	songDetails, err := s.songRepository.GetSong(artist, song.GetTitle())
+func (s *ConcurrentPlaylistService) fetchSong(
+	ctx context.Context,
+	artist string,
+	song setlist.Song,
+	ch chan<- FetchSongResult,
+) {
+	songDetails, err := s.songRepository.GetSong(ctx, artist, song.GetTitle())
 	ch <- FetchSongResult{Song: songDetails, Err: err}
 }

--- a/internal/playlist/concurrent_playlist_service_test.go
+++ b/internal/playlist/concurrent_playlist_service_test.go
@@ -63,8 +63,8 @@ func emptySetlist() setlist.Setlist {
 
 func defaultGetSongArgs() []song.GetSongArgs {
 	return []song.GetSongArgs{
-		{Artist: defaultArtist(), Title: "My song"},
-		{Artist: defaultArtist(), Title: "My other song"},
+		{Context: defaultContext(), Artist: defaultArtist(), Title: "My song"},
+		{Context: defaultContext(), Artist: defaultArtist(), Title: "My other song"},
 	}
 }
 

--- a/internal/playlist/mocks/playlist_service_mock.go
+++ b/internal/playlist/mocks/playlist_service_mock.go
@@ -1,0 +1,25 @@
+package playlist_mocks
+
+import (
+	"context"
+	"festwrap/internal/playlist"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type PlaylistServiceMock struct {
+	mock.Mock
+}
+
+func NewPlaylistServiceMock() PlaylistServiceMock {
+	return PlaylistServiceMock{}
+}
+
+func (s *PlaylistServiceMock) CreatePlaylist(ctx context.Context, playlistInput playlist.Playlist) (string, error) {
+	args := s.Called(ctx, playlistInput)
+	return args.String(0), args.Error(0)
+}
+
+func (s *PlaylistServiceMock) AddSetlist(ctx context.Context, playlistId string, artist string) error {
+	return s.Called(ctx, playlistId, artist).Error(0)
+}

--- a/internal/song/fake_song_repository.go
+++ b/internal/song/fake_song_repository.go
@@ -1,13 +1,15 @@
 package song
 
 import (
+	"context"
 	"fmt"
 	"sync"
 )
 
 type GetSongArgs struct {
-	Artist string
-	Title  string
+	Context context.Context
+	Artist  string
+	Title   string
 }
 
 type FakeSongRepository struct {
@@ -22,8 +24,8 @@ func NewFakeSongRepository() FakeSongRepository {
 	}
 }
 
-func (r *FakeSongRepository) GetSong(artist string, title string) (*Song, error) {
-	return r.repository.GetSong(artist, title)
+func (r *FakeSongRepository) GetSong(ctx context.Context, artist string, title string) (*Song, error) {
+	return r.repository.GetSong(ctx, artist, title)
 }
 
 func (r *FakeSongRepository) GetGetSongArgs() []GetSongArgs {
@@ -40,8 +42,8 @@ type WrappedFakeSongRepository struct {
 	mutex       sync.Mutex
 }
 
-func (w *WrappedFakeSongRepository) GetSong(artist string, title string) (*Song, error) {
-	w.getSongArgs = append(w.getSongArgs, GetSongArgs{Artist: artist, Title: title})
+func (w *WrappedFakeSongRepository) GetSong(ctx context.Context, artist string, title string) (*Song, error) {
+	w.getSongArgs = append(w.getSongArgs, GetSongArgs{Context: ctx, Artist: artist, Title: title})
 	return w.popSongLeft()
 }
 

--- a/internal/song/song_repository.go
+++ b/internal/song/song_repository.go
@@ -1,5 +1,7 @@
 package song
 
+import "context"
+
 type SongRepository interface {
-	GetSong(artist string, title string) (*Song, error)
+	GetSong(ctx context.Context, artist string, title string) (*Song, error)
 }


### PR DESCRIPTION
# Description

Adds an endpoint that adds the most recent setlist from the input artist to the given playlist.

# Testing

Start the app locally and make sure to provide the setlistFM api token:

```shell
FESTWRAP_SETLISTFM_APIKEY=XXX go run cmd/main.go
```

I created a custom playlist in Spotify to test this:

<img width="981" alt="Captura de pantalla 2025-02-19 a les 9 22 42" src="https://github.com/user-attachments/assets/b116078c-c8be-4086-bf7b-f90ff223e499" />

Then we query the endpoint in a separate terminal:

```shell
curl --location 'http://localhost:8080/playlists/<playlistId>' \
      --header 'Authorization: Bearer <token>' \
      --header 'Content-Type: application/json' \
      --data '{"artists":[{"name": "Silverstein"},{"name":"toe"}]}'
```

Note that:
- You can get a personal token using the [festwrap ui](https://github.com/DanielMoraDC/festwrap-ui).
- You can get the playlist id by selecting using the playlist link (`Share` -> `Copy playlist link`). The format will be something like this: `https://open.spotify.com/playlist/<id>?<params>`.

After that, we can see that the playlist is filled with data from the two given bands:

<img width="981" alt="Captura de pantalla 2025-02-19 a les 9 25 36" src="https://github.com/user-attachments/assets/f7bf7287-efa3-49fe-9df8-61ae59eb9df6" />

# Next steps

Create endpoint for creating a new playlist instead of updating an existing one.

After that, I will dedicate some time to reduce tech debt.