### PR TITLE
refactor: abstract update playlist builder in handler

### DIFF
--- a/cmd/handler/playlist/playlist_update.go
+++ b/cmd/handler/playlist/playlist_update.go
@@ -1,9 +1,0 @@
-package playlist
-
-type playlistArtist struct {
-	Name string `json:"name"`
-}
-
-type playlistUpdate struct {
-	Artists []playlistArtist `json:"artists"`
-}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,7 +18,7 @@ import (
 	"festwrap/internal/logging"
 	"festwrap/internal/playlist"
 	spotifyplaylists "festwrap/internal/playlist/spotify"
-	setlistfm "festwrap/internal/setlist/setlistfm"
+	"festwrap/internal/setlist/setlistfm"
 	spotifysongs "festwrap/internal/song/spotify"
 	spotifyusers "festwrap/internal/user/spotify"
 )
@@ -79,7 +79,7 @@ func main() {
 		setlistRepository,
 		songRepository,
 	)
-	playlistUpdateHandler := playlisthandler.NewUpdatePlaylistHandler(&playlistService, logger)
+	playlistUpdateHandler := playlisthandler.NewUpdateExistingPlaylistHandler("playlistId", &playlistService, logger)
 	mux.HandleFunc("/playlists/{playlistId}", playlistUpdateHandler.ServeHTTP)
 
 	wrappedMux := middleware.NewAuthTokenMiddleware(mux)

--- a/internal/playlist/mocks/playlist_update_builder_mock.go
+++ b/internal/playlist/mocks/playlist_update_builder_mock.go
@@ -1,0 +1,18 @@
+package playlist_mocks
+
+import (
+	"net/http"
+
+	"festwrap/internal/playlist"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type PlaylistUpdateBuilderMock struct {
+	mock.Mock
+}
+
+func (b *PlaylistUpdateBuilderMock) Build(request *http.Request) (playlist.PlaylistUpdate, error) {
+	args := b.Called(request)
+	return args.Get(0).(playlist.PlaylistUpdate), args.Error(1)
+}

--- a/internal/playlist/playlist_update.go
+++ b/internal/playlist/playlist_update.go
@@ -1,0 +1,14 @@
+package playlist
+
+type PlaylistArtist struct {
+	Name string `json:"name"`
+}
+
+type PlaylistArtists struct {
+	Artists []PlaylistArtist `json:"artists"`
+}
+
+type PlaylistUpdate struct {
+	PlaylistId string
+	Artists    []PlaylistArtist
+}

--- a/internal/playlist/playlist_update_builder.go
+++ b/internal/playlist/playlist_update_builder.go
@@ -1,0 +1,52 @@
+package playlist
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"festwrap/internal/serialization"
+)
+
+type PlaylistUpdateBuilder interface {
+	Build(request *http.Request) (PlaylistUpdate, error)
+}
+
+type ExistingPlaylistUpdateBuilder struct {
+	pathId       string
+	deserializer serialization.Deserializer[PlaylistArtists]
+}
+
+func NewExistingPlaylistUpdateBuilder(pathId string) ExistingPlaylistUpdateBuilder {
+	return ExistingPlaylistUpdateBuilder{
+		pathId:       pathId,
+		deserializer: serialization.NewJsonDeserializer[PlaylistArtists](),
+	}
+}
+
+func (b *ExistingPlaylistUpdateBuilder) Build(request *http.Request) (PlaylistUpdate, error) {
+	playlistId := request.PathValue(b.pathId)
+	if playlistId == "" {
+		return PlaylistUpdate{}, fmt.Errorf("could not find playlist id in %s", b.pathId)
+	}
+
+	defer request.Body.Close()
+	requestBody, err := io.ReadAll(request.Body)
+	if err != nil {
+		return PlaylistUpdate{}, errors.New("could read body from request")
+	}
+
+	var artists PlaylistArtists
+	err = b.deserializer.Deserialize(requestBody, &artists)
+	if err != nil {
+		return PlaylistUpdate{}, errors.New("failed to deserialize playlist artists: " + err.Error())
+	}
+
+	update := PlaylistUpdate{PlaylistId: playlistId, Artists: artists.Artists}
+	return update, nil
+}
+
+func (b *ExistingPlaylistUpdateBuilder) SetDeserializer(deserializer serialization.Deserializer[PlaylistArtists]) {
+	b.deserializer = deserializer
+}

--- a/internal/playlist/playlist_update_builder_test.go
+++ b/internal/playlist/playlist_update_builder_test.go
@@ -1,0 +1,101 @@
+package playlist
+
+import (
+	"bytes"
+	"errors"
+	"festwrap/internal/serialization"
+	"festwrap/internal/testtools"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	playlistId     = "myId"
+	playlistIdPath = "playlistId"
+)
+
+func updateBody() []byte {
+	return []byte(`{"artists":[{"name":"Silverstein"},{"name":"Chinese Football"}]}`)
+}
+
+func updateArtists() []PlaylistArtist {
+	return []PlaylistArtist{{Name: "Silverstein"}, {Name: "Chinese Football"}}
+}
+
+func buildRequest(t *testing.T, playlistId string, body []byte) *http.Request {
+	t.Helper()
+	requestUrl, err := url.Parse(fmt.Sprintf("https://example.com/playlist/{%s}", playlistIdPath))
+	if err != nil {
+		t.Errorf("Could not create request: %v", err.Error())
+	}
+
+	request := httptest.NewRequest("GET", requestUrl.String(), bytes.NewBuffer(body))
+	if playlistId != "" {
+		request.SetPathValue(playlistIdPath, playlistId)
+	}
+	return request
+}
+
+func TestExistingUpdateBuilderReturnsErrorIfPlaylistIdNotProvided(t *testing.T) {
+	request := buildRequest(t, "", updateBody())
+	builder := NewExistingPlaylistUpdateBuilder(playlistIdPath)
+
+	_, err := builder.Build(request)
+
+	assert.NotNil(t, err)
+}
+
+func TestExistingUpdateBuilderReturnsErrorOnIncorrectBody(t *testing.T) {
+	invalidBody := []byte("`some_incorrect_body}")
+	request := buildRequest(t, playlistId, invalidBody)
+	builder := NewExistingPlaylistUpdateBuilder(playlistIdPath)
+
+	_, err := builder.Build(request)
+
+	assert.NotNil(t, err)
+}
+
+func TestExistingUpdateBuilderReturnsErrorOnDeserializationError(t *testing.T) {
+	request := buildRequest(t, playlistId, updateBody())
+	deserializer := serialization.FakeDeserializer[PlaylistArtists]{}
+	deserializer.SetError(errors.New("some error"))
+	builder := NewExistingPlaylistUpdateBuilder(playlistIdPath)
+	builder.SetDeserializer(&deserializer)
+
+	_, err := builder.Build(request)
+
+	assert.NotNil(t, err)
+}
+
+func TestExistingUpdateBuilderReturnsDeserializedContent(t *testing.T) {
+	request := buildRequest(t, playlistId, updateBody())
+	deserializer := serialization.FakeDeserializer[PlaylistArtists]{}
+	deserializer.SetResponse(PlaylistArtists{Artists: updateArtists()})
+	builder := NewExistingPlaylistUpdateBuilder(playlistIdPath)
+	builder.SetDeserializer(&deserializer)
+
+	actual, err := builder.Build(request)
+
+	expected := PlaylistUpdate{PlaylistId: playlistId, Artists: updateArtists()}
+	assert.Equal(t, expected, actual)
+	assert.Nil(t, err)
+	assert.Equal(t, deserializer.GetArgs(), updateBody())
+}
+
+func TestExistingUpdateBuilderReturnsExpectedResultIntegration(t *testing.T) {
+	testtools.SkipOnShortRun(t)
+
+	request := buildRequest(t, playlistId, updateBody())
+	builder := NewExistingPlaylistUpdateBuilder(playlistIdPath)
+
+	actual, err := builder.Build(request)
+
+	expected := PlaylistUpdate{PlaylistId: playlistId, Artists: updateArtists()}
+	assert.Equal(t, expected, actual)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
# Description

Abstract update playlist detail extraction in order to reuse the main handler logic. We will use it for implementing the endpoint to create and add artists into the newly created playlist.