### PR TITLE
feat: FW-66 Implement add songs to new playlist endpoint

### DIFF
--- a/cmd/handler/playlist/update_playlist.go
+++ b/cmd/handler/playlist/update_playlist.go
@@ -42,6 +42,19 @@ func NewUpdateExistingPlaylistHandler(
 	}
 }
 
+func NewUpdateNewPlaylistHandler(
+	playlistService playlist.PlaylistService,
+	logger logging.Logger,
+) UpdatePlaylistHandler {
+	builder := builders.NewNewPlaylistUpdateBuilder(playlistService)
+	return UpdatePlaylistHandler{
+		playlistService:       playlistService,
+		logger:                logger,
+		playlistUpdateBuilder: &builder,
+		maxArtists:            5,
+	}
+}
+
 func (h *UpdatePlaylistHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	update, err := h.playlistUpdateBuilder.Build(r)
 	if err != nil {

--- a/cmd/handler/playlist/update_playlist_test.go
+++ b/cmd/handler/playlist/update_playlist_test.go
@@ -12,7 +12,6 @@ import (
 	"festwrap/internal/playlist"
 	playlistmocks "festwrap/internal/playlist/mocks"
 	buildermocks "festwrap/internal/playlist/update_builders/mocks"
-	"festwrap/internal/testtools"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -23,10 +22,7 @@ const (
 )
 
 func updateArtists() []playlist.PlaylistArtist {
-	return []playlist.PlaylistArtist{
-		playlist.PlaylistArtist{Name: "Comeback Kid"},
-		playlist.PlaylistArtist{Name: "Municipal Waste"},
-	}
+	return []playlist.PlaylistArtist{{Name: "Comeback Kid"}, {Name: "Municipal Waste"}}
 }
 
 func alwaysSuccessPlaylistService(request *http.Request) *playlistmocks.PlaylistServiceMock {
@@ -155,18 +151,4 @@ func TestUpdatePlaylistHandlerStatusOnPartialErrors(t *testing.T) {
 	handler.ServeHTTP(writer, request)
 
 	assert.Equal(t, http.StatusMultiStatus, writer.Code)
-}
-
-func TestUpdateExistingPlaylistHandlerIntegration(t *testing.T) {
-	testtools.SkipOnShortRun(t)
-
-	request := buildRequest(t)
-	request.SetPathValue(playlistIdPath, playlistId)
-	writer := httptest.NewRecorder()
-	playlistService := alwaysSuccessPlaylistService(request)
-	handler := NewUpdateExistingPlaylistHandler(playlistIdPath, playlistService, logging.NoopLogger{})
-
-	handler.ServeHTTP(writer, request)
-
-	assert.Equal(t, http.StatusCreated, writer.Code)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,8 +79,14 @@ func main() {
 		setlistRepository,
 		songRepository,
 	)
-	playlistUpdateHandler := playlisthandler.NewUpdateExistingPlaylistHandler("playlistId", &playlistService, logger)
-	mux.HandleFunc("/playlists/{playlistId}", playlistUpdateHandler.ServeHTTP)
+	existingPlaylistUpdateHandler := playlisthandler.NewUpdateExistingPlaylistHandler("playlistId", &playlistService, logger)
+	mux.HandleFunc("/playlists/{playlistId}", existingPlaylistUpdateHandler.ServeHTTP)
+
+	newPlaylistUpdateHandler := playlisthandler.NewUpdateNewPlaylistHandler(&playlistService, logger)
+	mux.HandleFunc(
+		"/playlists",
+		middleware.NewUserIdMiddleware(&newPlaylistUpdateHandler, userRepository).ServeHTTP,
+	)
 
 	wrappedMux := middleware.NewAuthTokenMiddleware(mux)
 	server := &http.Server{

--- a/internal/playlist/update_builders/playlist_update_builders.go
+++ b/internal/playlist/update_builders/playlist_update_builders.go
@@ -16,13 +16,18 @@ type PlaylistUpdateBuilder interface {
 
 type ExistingPlaylistUpdateBuilder struct {
 	pathId       string
-	deserializer serialization.Deserializer[PlaylistArtists]
+	deserializer serialization.Deserializer[ExistingPlaylistUpdate]
+}
+
+type NewPlaylistUpdateBuilder struct {
+	playlistService playlist.PlaylistService
+	deserializer    serialization.Deserializer[NewPlaylistUpdate]
 }
 
 func NewExistingPlaylistUpdateBuilder(pathId string) ExistingPlaylistUpdateBuilder {
 	return ExistingPlaylistUpdateBuilder{
 		pathId:       pathId,
-		deserializer: serialization.NewJsonDeserializer[PlaylistArtists](),
+		deserializer: serialization.NewJsonDeserializer[ExistingPlaylistUpdate](),
 	}
 }
 
@@ -38,7 +43,7 @@ func (b *ExistingPlaylistUpdateBuilder) Build(request *http.Request) (playlist.P
 		return playlist.PlaylistUpdate{}, errors.New("could read body from request")
 	}
 
-	var artists PlaylistArtists
+	var artists ExistingPlaylistUpdate
 	err = b.deserializer.Deserialize(requestBody, &artists)
 	if err != nil {
 		return playlist.PlaylistUpdate{}, errors.New("failed to deserialize playlist artists: " + err.Error())
@@ -52,6 +57,45 @@ func (b *ExistingPlaylistUpdateBuilder) Build(request *http.Request) (playlist.P
 	return update, nil
 }
 
-func (b *ExistingPlaylistUpdateBuilder) SetDeserializer(deserializer serialization.Deserializer[PlaylistArtists]) {
+func (b *ExistingPlaylistUpdateBuilder) SetDeserializer(deserializer serialization.Deserializer[ExistingPlaylistUpdate]) {
+	b.deserializer = deserializer
+}
+
+func NewNewPlaylistUpdateBuilder(playlistService playlist.PlaylistService) NewPlaylistUpdateBuilder {
+	return NewPlaylistUpdateBuilder{
+		playlistService: playlistService,
+		deserializer:    serialization.NewJsonDeserializer[NewPlaylistUpdate](),
+	}
+}
+
+func (b *NewPlaylistUpdateBuilder) Build(request *http.Request) (playlist.PlaylistUpdate, error) {
+	defer request.Body.Close()
+	requestBody, err := io.ReadAll(request.Body)
+	if err != nil {
+		return playlist.PlaylistUpdate{}, errors.New("could read body from request")
+	}
+
+	var update NewPlaylistUpdate
+	err = b.deserializer.Deserialize(requestBody, &update)
+	if err != nil {
+		return playlist.PlaylistUpdate{}, errors.New("failed to deserialize playlist information: " + err.Error())
+	}
+
+	playlistId, err := b.playlistService.CreatePlaylist(
+		request.Context(),
+		update.Playlist.toPlaylist(),
+	)
+	if err != nil {
+		return playlist.PlaylistUpdate{}, errors.New("could not create playlist")
+	}
+
+	playlistArtists := make([]playlist.PlaylistArtist, len(update.Artists))
+	for i, artist := range update.Artists {
+		playlistArtists[i] = playlist.PlaylistArtist{Name: artist.Name}
+	}
+	return playlist.PlaylistUpdate{PlaylistId: playlistId, Artists: playlistArtists}, nil
+}
+
+func (b *NewPlaylistUpdateBuilder) SetDeserializer(deserializer serialization.Deserializer[NewPlaylistUpdate]) {
 	b.deserializer = deserializer
 }

--- a/internal/playlist/update_builders/updates.go
+++ b/internal/playlist/update_builders/updates.go
@@ -1,9 +1,30 @@
 package update_builders
 
+import "festwrap/internal/playlist"
+
 type PlaylistArtist struct {
 	Name string `json:"name"`
 }
 
-type PlaylistArtists struct {
+type ExistingPlaylistUpdate struct {
 	Artists []PlaylistArtist `json:"artists"`
+}
+
+type NewPlaylist struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	IsPublic    bool   `json:"isPublic"`
+}
+
+func (p NewPlaylist) toPlaylist() playlist.Playlist {
+	return playlist.Playlist{
+		Name:        p.Name,
+		Description: p.Description,
+		IsPublic:    p.IsPublic,
+	}
+}
+
+type NewPlaylistUpdate struct {
+	ExistingPlaylistUpdate
+	Playlist NewPlaylist `json:"playlist"`
 }


### PR DESCRIPTION
# Description

Adds a new endpoint that allows to add songs for a new playlist. I favoured duplicating small amounts of code (e.g. test and body deserialization) over creating additional abstractions that might add too much complexity to the codebase.

# Testing

Start the API by typing:

```shell
FESTWRAP_SETLISTFM_APIKEY=<key>go run cmd/main.go
```

Then query the endpoint:

```shell
curl --location 'http://localhost:8080/playlists' \
    --header 'Authorization: Bearer <token>' \
    --header 'Content-Type: application/json' \
    --data '{"artists":[{"name": "Trophy Eyes"}],"playlist":{"name":"test1","description":"","isPublic":false}}'
```

Token can be manually obtained from [here](https://github.com/DanielMoraDC/festwrap-ui). We can see that it creates the following playlist:

<img width="948" alt="Captura de pantalla 2025-03-02 a les 13 25 01" src="https://github.com/user-attachments/assets/751b5259-c98e-4d43-ae61-520fac1d6b0c" />
