### PR TITLE
fix: FW-9 Use SetlistFM multiple pages in search

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,6 +45,7 @@ func main() {
 	maxConnsPerHost := GetEnvWithDefaultOrFail[int]("FESTWRAP_MAX_CONNS_PER_HOST", 10)
 	timeoutSeconds := GetEnvWithDefaultOrFail[int]("FESTWRAP_TIMEOUT_SECONDS", 5)
 	setlistfmApiKey := GetEnvStringOrFail("FESTWRAP_SETLISTFM_APIKEY")
+	maxSetlistFMNumSearchPages := GetEnvWithDefaultOrFail[int]("FESTWRAP_SETLISTFM_NUM_SEARCH_PAGES", 3)
 
 	slogLogger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	logger := logging.NewBaseLogger(slogLogger)
@@ -73,6 +74,7 @@ func main() {
 	)
 
 	setlistRepository := setlistfm.NewSetlistFMSetlistRepository(setlistfmApiKey, &httpSender)
+	setlistRepository.SetMaxPages(maxSetlistFMNumSearchPages)
 	songRepository := spotifysongs.NewSpotifySongRepository(&httpSender)
 	playlistService := playlist.NewConcurrentPlaylistService(
 		&playlistRepository,

--- a/internal/http/sender/mocks/sender_mock.go
+++ b/internal/http/sender/mocks/sender_mock.go
@@ -1,0 +1,21 @@
+package sender_mocks
+
+import (
+	httpsender "festwrap/internal/http/sender"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type HTTPSenderMock struct {
+	mock.Mock
+}
+
+func (s *HTTPSenderMock) Send(options httpsender.HTTPRequestOptions) (*[]byte, error) {
+	args := s.Called(options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	bytes := args.Get(0).(*[]byte)
+	return bytes, args.Error(1)
+}

--- a/internal/setlist/setlistfm/setlistfm_setlist_repository_test.go
+++ b/internal/setlist/setlistfm/setlistfm_setlist_repository_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func defaultArtist() string {
-	return "The Menzingers"
-}
+const (
+	artist = "The Menzingers"
+)
 
 func defaultMinSongs() int {
 	return 3
@@ -68,7 +68,7 @@ func TestGetSetlistSenderCalledWithProperOptions(t *testing.T) {
 	sender := defaultSender(t)
 	repository := NewSetlistFMSetlistRepository("some_api_key", sender)
 
-	repository.GetSetlist(defaultArtist(), defaultMinSongs())
+	repository.GetSetlist(artist, defaultMinSongs())
 
 	assert.Equal(t, sender.GetSendArgs(), expectedHttpOptions())
 }
@@ -78,7 +78,7 @@ func TestGetSetlistReturnsErrorOnSenderError(t *testing.T) {
 	sender.SetError(errors.New("test error"))
 	repository := NewSetlistFMSetlistRepository("some_api_key", &sender)
 
-	_, err := repository.GetSetlist(defaultArtist(), defaultMinSongs())
+	_, err := repository.GetSetlist(artist, defaultMinSongs())
 
 	assert.NotNil(t, err)
 }
@@ -89,7 +89,7 @@ func TestGetSetlistReturnsErrorOnDeserializationError(t *testing.T) {
 	sender.SetResponse(&invalidResponse)
 	repository := NewSetlistFMSetlistRepository("some_api_key", &sender)
 
-	_, err := repository.GetSetlist(defaultArtist(), defaultMinSongs())
+	_, err := repository.GetSetlist(artist, defaultMinSongs())
 
 	assert.NotNil(t, err)
 }
@@ -100,7 +100,7 @@ func TestGetSetlistReturnsErrorIfNoSetlistFound(t *testing.T) {
 	sender.SetResponse(&response)
 	repository := NewSetlistFMSetlistRepository("some_api_key", &sender)
 
-	_, err := repository.GetSetlist(defaultArtist(), defaultMinSongs())
+	_, err := repository.GetSetlist(artist, defaultMinSongs())
 
 	assert.NotNil(t, err)
 }
@@ -108,7 +108,7 @@ func TestGetSetlistReturnsErrorIfNoSetlistFound(t *testing.T) {
 func TestGetSetlistReturnsSetlist(t *testing.T) {
 	repository := NewSetlistFMSetlistRepository("some_api_key", defaultSender(t))
 
-	actual, _ := repository.GetSetlist(defaultArtist(), defaultMinSongs())
+	actual, _ := repository.GetSetlist(artist, defaultMinSongs())
 
 	assert.Equal(t, actual, expectedSetlist())
 }
@@ -116,7 +116,7 @@ func TestGetSetlistReturnsSetlist(t *testing.T) {
 func TestGetSetlistRetrievesErrorWhenMinSongsNotReached(t *testing.T) {
 	repository := NewSetlistFMSetlistRepository("some_api_key", defaultSender(t))
 
-	_, err := repository.GetSetlist(defaultArtist(), 50)
+	_, err := repository.GetSetlist(artist, 50)
 
 	assert.NotNil(t, err)
 }

--- a/internal/setlist/setlistfm/setlistfm_setlist_repository_test.go
+++ b/internal/setlist/setlistfm/setlistfm_setlist_repository_test.go
@@ -12,12 +12,9 @@ import (
 )
 
 const (
-	artist = "The Menzingers"
+	artist   = "The Menzingers"
+	minSongs = 3
 )
-
-func defaultMinSongs() int {
-	return 3
-}
 
 func responseBody(t *testing.T) []byte {
 	path := filepath.Join(testtools.GetParentDir(t), "testdata", "response.json")
@@ -68,7 +65,7 @@ func TestGetSetlistSenderCalledWithProperOptions(t *testing.T) {
 	sender := defaultSender(t)
 	repository := NewSetlistFMSetlistRepository("some_api_key", sender)
 
-	repository.GetSetlist(artist, defaultMinSongs())
+	repository.GetSetlist(artist, minSongs)
 
 	assert.Equal(t, sender.GetSendArgs(), expectedHttpOptions())
 }
@@ -78,7 +75,7 @@ func TestGetSetlistReturnsErrorOnSenderError(t *testing.T) {
 	sender.SetError(errors.New("test error"))
 	repository := NewSetlistFMSetlistRepository("some_api_key", &sender)
 
-	_, err := repository.GetSetlist(artist, defaultMinSongs())
+	_, err := repository.GetSetlist(artist, minSongs)
 
 	assert.NotNil(t, err)
 }
@@ -89,7 +86,7 @@ func TestGetSetlistReturnsErrorOnDeserializationError(t *testing.T) {
 	sender.SetResponse(&invalidResponse)
 	repository := NewSetlistFMSetlistRepository("some_api_key", &sender)
 
-	_, err := repository.GetSetlist(artist, defaultMinSongs())
+	_, err := repository.GetSetlist(artist, minSongs)
 
 	assert.NotNil(t, err)
 }
@@ -100,7 +97,7 @@ func TestGetSetlistReturnsErrorIfNoSetlistFound(t *testing.T) {
 	sender.SetResponse(&response)
 	repository := NewSetlistFMSetlistRepository("some_api_key", &sender)
 
-	_, err := repository.GetSetlist(artist, defaultMinSongs())
+	_, err := repository.GetSetlist(artist, minSongs)
 
 	assert.NotNil(t, err)
 }
@@ -108,7 +105,7 @@ func TestGetSetlistReturnsErrorIfNoSetlistFound(t *testing.T) {
 func TestGetSetlistReturnsSetlist(t *testing.T) {
 	repository := NewSetlistFMSetlistRepository("some_api_key", defaultSender(t))
 
-	actual, _ := repository.GetSetlist(artist, defaultMinSongs())
+	actual, _ := repository.GetSetlist(artist, minSongs)
 
 	assert.Equal(t, actual, expectedSetlist())
 }

--- a/internal/setlist/testdata/no_setlists_response.json
+++ b/internal/setlist/testdata/no_setlists_response.json
@@ -1,0 +1,6 @@
+{
+    "setlist": [],
+    "total": 0,
+    "page": 1,
+    "itemsPerPage": 0
+}


### PR DESCRIPTION
# Description

If a setlist is not found in first page, searches up to `n` pages for a result. Fails otherwise.

I also stopped replacing the deserializer dependency. Given it is not a slow one or a shared/out-of-process one, by keeping it in the test we make tests less coupled to the implementation and simpler to implement and extend. Therefore, we have moved the existing integration tests in that test suite into unit tests.

Additional minor changes:
- Use mocks for HTTP sender instead of fake in order to simplify test code and ease maintainability.
- Use simpler and concise naming in tests.

## Testing

Successfully reproduced test in [here](https://github.com/DanielMoraDC/festwrap-server/pull/49).