### PR TITLE
chore(tests): use consistent assert order

### DIFF
--- a/cmd/handler/playlist/update_playlist_test.go
+++ b/cmd/handler/playlist/update_playlist_test.go
@@ -79,7 +79,7 @@ func TestUpdatePlaylistHandlerReturnsErrorOnUpdateBuilderError(t *testing.T) {
 
 	handler.ServeHTTP(writer, request)
 
-	assert.Equal(t, writer.Code, http.StatusBadRequest)
+	assert.Equal(t, http.StatusBadRequest, writer.Code)
 }
 
 func TestUpdatePlaylistHandlerReturnsErrorIfArtistsOutOfBounds(t *testing.T) {
@@ -111,7 +111,7 @@ func TestUpdatePlaylistHandlerReturnsErrorIfArtistsOutOfBounds(t *testing.T) {
 
 			handler.ServeHTTP(writer, request)
 
-			assert.Equal(t, writer.Code, http.StatusBadRequest)
+			assert.Equal(t, http.StatusBadRequest, writer.Code)
 		})
 	}
 }

--- a/cmd/handler/search/search_test.go
+++ b/cmd/handler/search/search_test.go
@@ -84,7 +84,7 @@ func TestBadRequestIfNameNotProvided(t *testing.T) {
 
 	handler.ServeHTTP(writer, request)
 
-	assert.Equal(t, writer.Code, http.StatusBadRequest)
+	assert.Equal(t, http.StatusBadRequest, writer.Code)
 }
 
 func TestLimitStatusCodeDependingOnValue(t *testing.T) {
@@ -125,7 +125,7 @@ func TestLimitStatusCodeDependingOnValue(t *testing.T) {
 
 			handler.ServeHTTP(writer, request)
 
-			assert.Equal(t, writer.Code, test.status)
+			assert.Equal(t, test.status, writer.Code)
 		})
 	}
 }
@@ -139,9 +139,9 @@ func TestSearcherCalledWithParams(t *testing.T) {
 	handler.ServeHTTP(httptest.NewRecorder(), request)
 
 	actual := searcher.GetSearchArgs()
-	assert.Equal(t, actual.Context, request.Context())
-	assert.Equal(t, fmt.Sprint(actual.Limit), defaultQueryParams()["limit"])
-	assert.Equal(t, actual.Name, defaultQueryParams()["name"])
+	assert.Equal(t, request.Context(), actual.Context)
+	assert.Equal(t, defaultQueryParams()["limit"], fmt.Sprint(actual.Limit))
+	assert.Equal(t, defaultQueryParams()["name"], actual.Name)
 }
 
 func TestSearchReturnsInternalErrorOnEncoderError(t *testing.T) {
@@ -152,7 +152,7 @@ func TestSearchReturnsInternalErrorOnEncoderError(t *testing.T) {
 
 	handler.ServeHTTP(writer, request)
 
-	assert.Equal(t, writer.Code, http.StatusInternalServerError)
+	assert.Equal(t, http.StatusInternalServerError, writer.Code)
 }
 
 func TestSearchReturnsExpectedResult(t *testing.T) {
@@ -162,6 +162,6 @@ func TestSearchReturnsExpectedResult(t *testing.T) {
 
 	handler.ServeHTTP(writer, request)
 
-	assert.Equal(t, writer.Code, http.StatusOK)
-	assert.Equal(t, unmarshalSearchResponse(t, writer.Body.Bytes()), defaultResults())
+	assert.Equal(t, http.StatusOK, writer.Code)
+	assert.Equal(t, defaultResults(), unmarshalSearchResponse(t, writer.Body.Bytes()))
 }

--- a/cmd/middleware/auth_token_test.go
+++ b/cmd/middleware/auth_token_test.go
@@ -36,7 +36,7 @@ func TestBadRequestErrorOnMissingAuthHeader(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	assert.Equal(t, writer.Code, http.StatusBadRequest)
+	assert.Equal(t, http.StatusBadRequest, writer.Code)
 }
 
 func TestUnprocessableEntityErrorOnWronglyFormattedAuthHeader(t *testing.T) {
@@ -45,7 +45,7 @@ func TestUnprocessableEntityErrorOnWronglyFormattedAuthHeader(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	assert.Equal(t, writer.Code, http.StatusUnprocessableEntity)
+	assert.Equal(t, http.StatusUnprocessableEntity, writer.Code)
 }
 
 func TestTokenIsPlacedInExpectedContextKey(t *testing.T) {
@@ -54,7 +54,7 @@ func TestTokenIsPlacedInExpectedContextKey(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	assert.Equal(t, writer.Body.String(), "1234")
+	assert.Equal(t, "1234", writer.Body.String())
 }
 
 func TestMiddlewareReturnsStatusCodeofTheHandler(t *testing.T) {
@@ -63,5 +63,5 @@ func TestMiddlewareReturnsStatusCodeofTheHandler(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	assert.Equal(t, writer.Code, http.StatusAccepted)
+	assert.Equal(t, http.StatusAccepted, writer.Code)
 }

--- a/cmd/middleware/user_id_test.go
+++ b/cmd/middleware/user_id_test.go
@@ -49,7 +49,7 @@ func TestGetUserIdCallsRepositoryWithRequestContext(t *testing.T) {
 	middleware.ServeHTTP(writer, request)
 
 	fakeRepository := middleware.GetUserRepository().(*user.FakeUserRepository)
-	assert.Equal(t, fakeRepository.GetGetCurrentIdArgs().Context, request.Context())
+	assert.Equal(t, request.Context(), fakeRepository.GetGetCurrentIdArgs().Context)
 }
 
 func TestGetUserReturnsInternalErrorOnRepositoryError(t *testing.T) {
@@ -60,7 +60,7 @@ func TestGetUserReturnsInternalErrorOnRepositoryError(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	assert.Equal(t, writer.Result().StatusCode, http.StatusInternalServerError)
+	assert.Equal(t, http.StatusInternalServerError, writer.Result().StatusCode)
 }
 
 func TestUserIsPlacedInExpectedContextKey(t *testing.T) {
@@ -68,7 +68,7 @@ func TestUserIsPlacedInExpectedContextKey(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	assert.Equal(t, writer.Body.String(), "some_id")
+	assert.Equal(t, "some_id", writer.Body.String())
 }
 
 func TestUserIdMiddlewareReturnsStatusCodeofTheHandler(t *testing.T) {
@@ -76,5 +76,5 @@ func TestUserIdMiddlewareReturnsStatusCodeofTheHandler(t *testing.T) {
 
 	middleware.ServeHTTP(writer, request)
 
-	assert.Equal(t, writer.Code, http.StatusContinue)
+	assert.Equal(t, http.StatusContinue, writer.Code)
 }

--- a/internal/artist/spotify/spotify_artist_repository_test.go
+++ b/internal/artist/spotify/spotify_artist_repository_test.go
@@ -131,7 +131,7 @@ func TestSearchArtistSendsRequestWithProperOptions(t *testing.T) {
 	_, err := repository.SearchArtist(defaultContext(), defaultSearchName(), defaultLimit())
 
 	assert.Nil(t, err)
-	assert.Equal(t, sender.GetSendArgs(), expectedHttpOptions())
+	assert.Equal(t, expectedHttpOptions(), sender.GetSendArgs())
 }
 
 func TestSearchArtistReturnsErrorOnWrongKeyType(t *testing.T) {
@@ -162,7 +162,7 @@ func TestSearchArtistCallsDeserializeWithSendResponseBody(t *testing.T) {
 	_, err := repository.SearchArtist(defaultContext(), defaultSearchName(), defaultLimit())
 
 	assert.Nil(t, err)
-	assert.Equal(t, deserializer.GetArgs(), defaultResponse())
+	assert.Equal(t, defaultResponse(), deserializer.GetArgs())
 }
 
 func TestSearchArtistsReturnsErrorOnResponseBodyDeserializationError(t *testing.T) {
@@ -193,7 +193,7 @@ func TestSearchArtistReturnsEmptyIfNoneFound(t *testing.T) {
 
 	artists, _ := repository.SearchArtist(defaultContext(), defaultSearchName(), defaultLimit())
 
-	assert.Equal(t, artists, []artist.Artist{})
+	assert.Equal(t, []artist.Artist{}, artists)
 }
 
 func TestSearchArtistReturnsDeserializedArtistsIntegration(t *testing.T) {
@@ -207,5 +207,5 @@ func TestSearchArtistReturnsDeserializedArtistsIntegration(t *testing.T) {
 
 	artists, _ := repository.SearchArtist(defaultContext(), defaultSearchName(), defaultLimit())
 
-	assert.Equal(t, artists, integrationArtists())
+	assert.Equal(t, integrationArtists(), artists)
 }

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -21,7 +21,7 @@ func TestGetEnvReturnsDefaultValueIfDoesntExist(t *testing.T) {
 		defaultValue := "something"
 		value, _ := GetEnvWithDefault("MY_KEY", defaultValue)
 
-		assert.Equal(t, value, defaultValue)
+		assert.Equal(t, defaultValue, value)
 	})
 }
 
@@ -32,7 +32,7 @@ func TestGetEnvReturnsExistingEnvVariable(t *testing.T) {
 		os.Setenv(key, value)
 		actual, _ := GetEnvWithDefault(key, 0)
 
-		assert.Equal(t, actual, 42)
+		assert.Equal(t, 42, actual)
 	})
 
 	t.Run("string", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestGetEnvReturnsExistingEnvVariable(t *testing.T) {
 		os.Setenv(key, value)
 		actual, _ := GetEnvWithDefault(key, "")
 
-		assert.Equal(t, actual, value)
+		assert.Equal(t, value, actual)
 	})
 }
 

--- a/internal/http/sender/base_sender_test.go
+++ b/internal/http/sender/base_sender_test.go
@@ -59,7 +59,7 @@ func TestSendRequestHasProvidedMethod(t *testing.T) {
 
 	expected := client.GetRequestArg()
 	actual := string(options.GetMethod())
-	assert.Equal(t, actual, expected.Method)
+	assert.Equal(t, expected.Method, actual)
 	assert.Nil(t, err)
 }
 
@@ -70,7 +70,7 @@ func TestSendRequestHasProvidedUrl(t *testing.T) {
 
 	expected := client.GetRequestArg()
 	actual := options.GetUrl()
-	assert.Equal(t, actual, expected.URL.String())
+	assert.Equal(t, expected.URL.String(), actual)
 	assert.Nil(t, err)
 }
 
@@ -81,7 +81,7 @@ func TestSendRequestHasProvidedBody(t *testing.T) {
 
 	expected := client.GetRequestArg()
 	actual := options.GetBody()
-	assert.Equal(t, actual, readBodyFromRequest(t, expected))
+	assert.Equal(t, readBodyFromRequest(t, expected), actual)
 	assert.Nil(t, err)
 }
 
@@ -107,8 +107,8 @@ func TestSendRequestUsesHeaders(t *testing.T) {
 
 	_, err := sender.Send(options)
 
-	expected := client.GetRequestArg()
-	assertHeadersMatch(t, headers, expected.Header)
+	actual := client.GetRequestArg()
+	assertHeadersMatch(t, headers, actual.Header)
 	assert.Nil(t, err)
 }
 
@@ -165,7 +165,7 @@ func TestSendRequestReturnsResponseBody(t *testing.T) {
 
 	body, err := sender.Send(options)
 
-	assert.Equal(t, string(*body), string(defaultResponseBody()))
+	assert.Equal(t, string(defaultResponseBody()), string(*body))
 	assert.Nil(t, err)
 }
 

--- a/internal/playlist/concurrent_playlist_service_test.go
+++ b/internal/playlist/concurrent_playlist_service_test.go
@@ -118,7 +118,7 @@ func TestCreatePlaylistRepositoryCalledWithArgs(t *testing.T) {
 	actual := playlistRepository.GetCreatePlaylistArgs()
 	expected := CreatePlaylistArgs{Context: defaultContext(), Playlist: defaultPlaylist()}
 	assert.Nil(t, err)
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func TestCreatePlaylistReturnsPlaylistIdOnSuccess(t *testing.T) {
@@ -129,7 +129,7 @@ func TestCreatePlaylistReturnsPlaylistIdOnSuccess(t *testing.T) {
 
 	actual, err := service.CreatePlaylist(defaultContext(), defaultPlaylist())
 
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 	assert.Nil(t, err)
 }
 
@@ -156,7 +156,7 @@ func TestAddSetlistSetlistRepositoryCalledWithArgs(t *testing.T) {
 	actual := setlistRepository.GetGetSetlistArgs()
 	expected := setlist.GetSetlistArgs{Artist: artist, MinSongs: minSongs}
 	assert.Nil(t, err)
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func TestAddSetlistReturnsErrorOnSetlistRepositoryError(t *testing.T) {
@@ -179,7 +179,7 @@ func TestAddSetlistSongRepositoryCalledWithSetlistSongs(t *testing.T) {
 	actual := songRepository.GetGetSongArgs()
 	expected := defaultGetSongArgs()
 	assert.Nil(t, err)
-	if !testtools.HaveSameElements(actual, expected) {
+	if !testtools.HaveSameElements(expected, actual) {
 		t.Errorf("Expected called songs %v, found %v", expected, actual)
 	}
 }
@@ -194,7 +194,7 @@ func TestAddSetlistAddsSongsFetched(t *testing.T) {
 	actual := playlistRepository.GetAddSongArgs()
 	expected := defaultAddSongsArgs()
 	assert.Nil(t, err)
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func TestAddSetlistAddsOnlySongsFetchedWithoutError(t *testing.T) {
@@ -207,7 +207,7 @@ func TestAddSetlistAddsOnlySongsFetchedWithoutError(t *testing.T) {
 	actual := playlistRepository.GetAddSongArgs()
 	expected := addSongsArgsWithErrors()
 	assert.Nil(t, err)
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func TestAddSetlistSetlistRaisesErrorIfSetlistEmpty(t *testing.T) {

--- a/internal/playlist/spotify/spotify_playlist_repository_test.go
+++ b/internal/playlist/spotify/spotify_playlist_repository_test.go
@@ -217,7 +217,7 @@ func TestAddSongsSerializesInputSongs(t *testing.T) {
 
 	expected := SpotifySongs{Uris: []string{"uri1", "uri2"}}
 	actual := repository.GetSongSerializer().(*serialization.FakeSerializer[SpotifySongs]).GetArgs()
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func TestAddSongsReturnsErrorOnNonSerializationError(t *testing.T) {
@@ -237,7 +237,7 @@ func TestAddSongsSendsRequestUsingProperOptions(t *testing.T) {
 	repository.AddSongs(defaultContext(), addSongsPlaylistId, songsToAdd())
 
 	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
-	assert.Equal(t, actual, expectedAddSongsHttpOptions())
+	assert.Equal(t, expectedAddSongsHttpOptions(), actual)
 }
 
 func TestAddSongsReturnsErrorOnSendError(t *testing.T) {
@@ -256,7 +256,7 @@ func TestAddSongsSerializesInputPlaylist(t *testing.T) {
 
 	expected := SpotifyPlaylist{Name: "my-playlist", Description: "some playlist", IsPublic: false}
 	actual := repository.GetPlaylistCreateSerializer().(*serialization.FakeSerializer[SpotifyPlaylist]).GetArgs()
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func TestCreatePlaylistReturnsErrorOnPlaylistSerializationError(t *testing.T) {
@@ -276,7 +276,7 @@ func TestCreatePlaylistSendsCreateRequestWithOptions(t *testing.T) {
 	repository.CreatePlaylist(defaultContext(), playlistToCreate())
 
 	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
-	assert.Equal(t, actual, expectedCreatePlaylistHttpOptions())
+	assert.Equal(t, expectedCreatePlaylistHttpOptions(), actual)
 }
 
 func TestCreatePlaylistReturnsErrorOnDeserializationError(t *testing.T) {
@@ -299,7 +299,7 @@ func TestCreatePlaylistReturnsIdFromDeserializedResponse(t *testing.T) {
 
 	actual, _ := repository.CreatePlaylist(defaultContext(), playlistToCreate())
 
-	assert.Equal(t, actual, deserialized.Id)
+	assert.Equal(t, deserialized.Id, actual)
 }
 
 func TestCreatePlaylistReturnsErrorOnSendError(t *testing.T) {
@@ -317,7 +317,7 @@ func TestSearchPlaylistSendsCreateRequestWithOptions(t *testing.T) {
 	repository.SearchPlaylist(defaultContext(), searchPlaylistName, searchPlaylistLimit)
 
 	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
-	assert.Equal(t, actual, expectedSearchPlaylistHttpOptions())
+	assert.Equal(t, expectedSearchPlaylistHttpOptions(), actual)
 }
 
 func TestSearchPlaylistReturnsErrorOnSendError(t *testing.T) {
@@ -346,7 +346,7 @@ func TestSearchPlaylistReturnsDeserializedContent(t *testing.T) {
 	actual, err := repository.SearchPlaylist(defaultContext(), searchPlaylistName, searchPlaylistLimit)
 
 	assert.Nil(t, err)
-	assert.Equal(t, actual, searchedFilteredPlaylists())
+	assert.Equal(t, searchedFilteredPlaylists(), actual)
 }
 
 func TestAddSongsPlaylistSendsOptionsUsingSerializerIntegration(t *testing.T) {
@@ -359,7 +359,7 @@ func TestAddSongsPlaylistSendsOptionsUsingSerializerIntegration(t *testing.T) {
 	repository.AddSongs(defaultContext(), addSongsPlaylistId, songsToAdd())
 
 	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
-	assert.Equal(t, actual, expectedAddSongsHttpOptions())
+	assert.Equal(t, expectedAddSongsHttpOptions(), actual)
 }
 
 func TestCreatePlaylistSendsOptionsUsingSerializerIntegration(t *testing.T) {
@@ -372,7 +372,7 @@ func TestCreatePlaylistSendsOptionsUsingSerializerIntegration(t *testing.T) {
 	repository.CreatePlaylist(defaultContext(), playlistToCreate())
 
 	actual := repository.GetHTTPSender().(*httpsender.FakeHTTPSender).GetSendArgs()
-	assert.Equal(t, actual, expectedCreatePlaylistHttpOptions())
+	assert.Equal(t, expectedCreatePlaylistHttpOptions(), actual)
 }
 
 func TestCreatePlaylistReturnsResultsUsingDeserializerIntegration(t *testing.T) {
@@ -389,7 +389,7 @@ func TestCreatePlaylistReturnsResultsUsingDeserializerIntegration(t *testing.T) 
 	id, err := repository.CreatePlaylist(defaultContext(), playlistToCreate())
 
 	assert.Nil(t, err)
-	assert.Equal(t, id, createPlaylistId)
+	assert.Equal(t, createPlaylistId, id)
 }
 
 func TestSearchPlaylistReturnsResultsUsingDeserializerIntegration(t *testing.T) {
@@ -405,7 +405,7 @@ func TestSearchPlaylistReturnsResultsUsingDeserializerIntegration(t *testing.T) 
 
 	actual, err := repository.SearchPlaylist(defaultContext(), searchPlaylistName, searchPlaylistLimit)
 
-	assert.Equal(t, actual, searchedFilteredPlaylists())
+	assert.Equal(t, searchedFilteredPlaylists(), actual)
 	assert.Nil(t, err)
 }
 

--- a/internal/playlist/update_builders/playlist_update_builders_test.go
+++ b/internal/playlist/update_builders/playlist_update_builders_test.go
@@ -156,7 +156,7 @@ func TestExistingUpdateBuilderReturnsDeserializedContent(t *testing.T) {
 	expected := playlistUpdate()
 	assert.Equal(t, expected, actual)
 	assert.Nil(t, err)
-	assert.Equal(t, deserializer.GetArgs(), existingPlaylistUpdateBody())
+	assert.Equal(t, existingPlaylistUpdateBody(), deserializer.GetArgs())
 }
 
 func TestNewUpdateBuilderReturnsExpectedUpdate(t *testing.T) {

--- a/internal/serialization/json_deserializer_test.go
+++ b/internal/serialization/json_deserializer_test.go
@@ -14,7 +14,7 @@ func TestJsonDeserializerProducesExpectedResult(t *testing.T) {
 
 	expected := serializableObject()
 	assert.Nil(t, err)
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func TestJsonDeserializerReturnsErrorOnNonJsonInput(t *testing.T) {

--- a/internal/serialization/json_serializer_test.go
+++ b/internal/serialization/json_serializer_test.go
@@ -14,7 +14,7 @@ func TestBaseSerializerReturnsExpectedOutput(t *testing.T) {
 
 	expected := serializableObjectBytes()
 	assert.Nil(t, err)
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func TestBaseSerializerReturnsErrorOnNonSerializableObject(t *testing.T) {

--- a/internal/setlist/setlistfm/setlistfm_setlist_repository_test.go
+++ b/internal/setlist/setlistfm/setlistfm_setlist_repository_test.go
@@ -111,7 +111,7 @@ func TestGetSetlistReturnsSetlist(t *testing.T) {
 
 	actual, _ := repository.GetSetlist(artist, minSongs)
 
-	assert.Equal(t, actual, expectedSetlist())
+	assert.Equal(t, expectedSetlist(), actual)
 }
 
 func TestGetSetlistRetrievesErrorWhenMinSongsNotReached(t *testing.T) {

--- a/internal/song/spotify/spotify_song_repository_test.go
+++ b/internal/song/spotify/spotify_song_repository_test.go
@@ -93,7 +93,7 @@ func TestGetSongSendsRequestWithProperOptions(t *testing.T) {
 	_, err := repository.GetSong(defaultContext(), defaultArtist(), defaultTitle())
 
 	assert.Nil(t, err)
-	assert.Equal(t, sender.GetSendArgs(), expectedHttpOptions())
+	assert.Equal(t, expectedHttpOptions(), sender.GetSendArgs())
 }
 
 func TestGetSongReturnsErrorOnSendError(t *testing.T) {
@@ -114,7 +114,7 @@ func TestGetSongCallsDeserializeWithSendResponseBody(t *testing.T) {
 	_, err := repository.GetSong(defaultContext(), defaultArtist(), defaultTitle())
 
 	assert.Nil(t, err)
-	assert.Equal(t, deserializer.GetArgs(), defaultResponse())
+	assert.Equal(t, defaultResponse(), deserializer.GetArgs())
 }
 
 func TestGetSongReturnsErrorOnResponseBodyDeserializationError(t *testing.T) {
@@ -147,7 +147,7 @@ func TestGetSongReturnsFirstSongFound(t *testing.T) {
 
 	expected := song.NewSong(defaultDeserializedResponse().Tracks.Songs[0].Uri)
 	assert.Nil(t, err)
-	assert.Equal(t, *actual, expected)
+	assert.Equal(t, expected, *actual)
 }
 
 func TestGetSongReturnErrorWhenInvalidToken(t *testing.T) {
@@ -194,5 +194,5 @@ func TestGetSongReturnsFirstSongFoundIntegration(t *testing.T) {
 
 	expected := song.NewSong("spotify:track:4rH1kFLYW0b28UNRyn7dK3")
 	assert.Nil(t, err)
-	assert.Equal(t, *actual, expected)
+	assert.Equal(t, expected, *actual)
 }

--- a/internal/user/spotify/spotify_user_repository_test.go
+++ b/internal/user/spotify/spotify_user_repository_test.go
@@ -97,7 +97,7 @@ func TestGetCurrentUserIdSendsRequestWithProperOptions(t *testing.T) {
 	_, err := repository.GetCurrentUserId(defaultContext())
 
 	assert.Nil(t, err)
-	assert.Equal(t, sender.GetSendArgs(), expectedHttpOptions())
+	assert.Equal(t, expectedHttpOptions(), sender.GetSendArgs())
 }
 
 func TestGetCurrentUserReturnsErrorOnSendError(t *testing.T) {
@@ -117,7 +117,7 @@ func TestGetCurrentUserCallsDeserializeWithSendResponseBody(t *testing.T) {
 
 	assert.Nil(t, err)
 	deserializer := repository.GetDeserializer().(*serialization.FakeDeserializer[spotifyUserResponse])
-	assert.Equal(t, deserializer.GetArgs(), defaultResponse())
+	assert.Equal(t, defaultResponse(), deserializer.GetArgs())
 }
 
 func TestGetCurrentUserReturnsErrorOnResponseBodyDeserializationError(t *testing.T) {
@@ -141,5 +141,5 @@ func TestGetCurrentUserReturnsFirstSongFoundIntegration(t *testing.T) {
 
 	expected := "my_id"
 	assert.Nil(t, err)
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
# Description

Changes order of asserts so they are consistent within the project and with Testify.