### PR TITLE
feat: FW-88 return playlist id on create

### DIFF
--- a/cmd/handler/playlist/update_playlist.go
+++ b/cmd/handler/playlist/update_playlist.go
@@ -4,15 +4,26 @@ import (
 	"festwrap/internal/logging"
 	"festwrap/internal/playlist"
 	builders "festwrap/internal/playlist/update_builders"
+	"festwrap/internal/serialization"
 	"fmt"
 	"net/http"
 )
+
+type Playlist struct {
+	Id string `json:"id"`
+}
+
+type UpdatePlaylistResponse struct {
+	Playlist Playlist `json:"playlist"`
+}
 
 type UpdatePlaylistHandler struct {
 	playlistService       playlist.PlaylistService
 	logger                logging.Logger
 	playlistUpdateBuilder playlist.PlaylistUpdateBuilder
 	maxArtists            int
+	returnResponse        bool
+	responseEncoder       serialization.Encoder[UpdatePlaylistResponse]
 }
 
 func NewUpdatePlaylistHandler(
@@ -20,11 +31,14 @@ func NewUpdatePlaylistHandler(
 	playlistUpdateBuilder playlist.PlaylistUpdateBuilder,
 	logger logging.Logger,
 ) UpdatePlaylistHandler {
+	responseEncoder := serialization.NewJsonEncoder[UpdatePlaylistResponse]()
 	return UpdatePlaylistHandler{
 		playlistService:       playlistService,
 		logger:                logger,
 		playlistUpdateBuilder: playlistUpdateBuilder,
 		maxArtists:            5,
+		returnResponse:        false,
+		responseEncoder:       &responseEncoder,
 	}
 }
 
@@ -34,12 +48,8 @@ func NewUpdateExistingPlaylistHandler(
 	logger logging.Logger,
 ) UpdatePlaylistHandler {
 	builder := builders.NewExistingPlaylistUpdateBuilder(pathId)
-	return UpdatePlaylistHandler{
-		playlistService:       playlistService,
-		logger:                logger,
-		playlistUpdateBuilder: &builder,
-		maxArtists:            5,
-	}
+	handler := NewUpdatePlaylistHandler(playlistService, &builder, logger)
+	return handler
 }
 
 func NewUpdateNewPlaylistHandler(
@@ -47,12 +57,9 @@ func NewUpdateNewPlaylistHandler(
 	logger logging.Logger,
 ) UpdatePlaylistHandler {
 	builder := builders.NewNewPlaylistUpdateBuilder(playlistService)
-	return UpdatePlaylistHandler{
-		playlistService:       playlistService,
-		logger:                logger,
-		playlistUpdateBuilder: &builder,
-		maxArtists:            5,
-	}
+	handler := NewUpdatePlaylistHandler(playlistService, &builder, logger)
+	handler.ReturnResponse(true)
+	return handler
 }
 
 func (h *UpdatePlaylistHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -86,8 +93,17 @@ func (h *UpdatePlaylistHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	} else if errors > 0 {
 		statusCode = http.StatusInternalServerError
 	}
-
 	w.WriteHeader(statusCode)
+
+	if h.returnResponse {
+		response := UpdatePlaylistResponse{Playlist: Playlist{Id: update.PlaylistId}}
+		if err = h.responseEncoder.Encode(w, response); err != nil {
+			message := fmt.Sprintf("encoding error: could not encode response: %v", err)
+			h.logger.Error(message)
+			http.Error(w, "unexpected error: could not encode response", http.StatusInternalServerError)
+			return
+		}
+	}
 }
 
 func (h *UpdatePlaylistHandler) SetPlaylistUpdateBuilder(builder playlist.PlaylistUpdateBuilder) {
@@ -104,4 +120,8 @@ func (h *UpdatePlaylistHandler) SetPlaylistService(service playlist.PlaylistServ
 
 func (h *UpdatePlaylistHandler) SetMaxArtists(limit int) {
 	h.maxArtists = limit
+}
+
+func (h *UpdatePlaylistHandler) ReturnResponse(flag bool) {
+	h.returnResponse = flag
 }

--- a/cmd/handler/playlist/update_playlist.go
+++ b/cmd/handler/playlist/update_playlist.go
@@ -24,6 +24,7 @@ type UpdatePlaylistHandler struct {
 	maxArtists            int
 	returnResponse        bool
 	responseEncoder       serialization.Encoder[UpdatePlaylistResponse]
+	successStatusCode     int
 }
 
 func NewUpdatePlaylistHandler(
@@ -39,6 +40,7 @@ func NewUpdatePlaylistHandler(
 		maxArtists:            5,
 		returnResponse:        false,
 		responseEncoder:       &responseEncoder,
+		successStatusCode:     http.StatusCreated,
 	}
 }
 
@@ -59,6 +61,7 @@ func NewUpdateNewPlaylistHandler(
 	builder := builders.NewNewPlaylistUpdateBuilder(playlistService)
 	handler := NewUpdatePlaylistHandler(playlistService, &builder, logger)
 	handler.ReturnResponse(true)
+	handler.SetSuccessStatusCode(http.StatusOK)
 	return handler
 }
 
@@ -87,7 +90,7 @@ func (h *UpdatePlaylistHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	statusCode := http.StatusCreated
+	statusCode := h.successStatusCode
 	if errors > 0 && errors < len(update.Artists) {
 		statusCode = http.StatusMultiStatus
 	} else if errors > 0 {
@@ -124,4 +127,8 @@ func (h *UpdatePlaylistHandler) SetMaxArtists(limit int) {
 
 func (h *UpdatePlaylistHandler) ReturnResponse(flag bool) {
 	h.returnResponse = flag
+}
+
+func (h *UpdatePlaylistHandler) SetSuccessStatusCode(status int) {
+	h.successStatusCode = status
 }

--- a/cmd/handler/playlist/update_playlist_test.go
+++ b/cmd/handler/playlist/update_playlist_test.go
@@ -3,6 +3,7 @@ package playlist
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -151,4 +152,33 @@ func TestUpdatePlaylistHandlerStatusOnPartialErrors(t *testing.T) {
 	handler.ServeHTTP(writer, request)
 
 	assert.Equal(t, http.StatusMultiStatus, writer.Code)
+}
+
+func TestUpdatePlaylistHandlerShouldReturnResponseIfEnabled(t *testing.T) {
+	tests := map[string]struct {
+		returnResponse bool
+		expected       string
+	}{
+		"enabled": {
+			returnResponse: true,
+			expected:       fmt.Sprintf("{\"playlist\":{\"id\":\"%s\"}}\n", playlistId),
+		},
+		"disabled": {
+			returnResponse: false,
+			expected:       "",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			handler, request, writer := setup(t)
+			handler.ReturnResponse(test.returnResponse)
+
+			handler.ServeHTTP(writer, request)
+
+			assert.Equal(t, http.StatusCreated, writer.Code)
+			assert.Equal(t, test.expected, writer.Body.String())
+		})
+	}
 }

--- a/cmd/handler/playlist/update_playlist_test.go
+++ b/cmd/handler/playlist/update_playlist_test.go
@@ -182,3 +182,13 @@ func TestUpdatePlaylistHandlerShouldReturnResponseIfEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdatePlaylistHandlerReturnsGivenStatus(t *testing.T) {
+	status := http.StatusContinue
+	handler, request, writer := setup(t)
+	handler.SetSuccessStatusCode(status)
+
+	handler.ServeHTTP(writer, request)
+
+	assert.Equal(t, status, writer.Code)
+}


### PR DESCRIPTION
# Description

Returns playlist information (i.e. id) on creation. Also took the chance to return 201 status (created) only when a new playlist is created.

# Testing

## On updating existing playlist

```shell
❯ curl --location 'http://localhost:8080/playlists/25Fqk8HMi0LppHQliZx6ta' \
      --header 'Authorization: Bearer <token>' \
      --header 'Content-Type: application/json' \
      --data '{"artists":[{"name": "Stick to your guns"}]}' -v
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> POST /playlists/25Fqk8HMi0LppHQliZx6ta HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> Authorization: Bearer <token>
> Content-Type: application/json
> Content-Length: 44
> 
* upload completely sent off: 44 bytes
< HTTP/1.1 200 OK
< Date: Mon, 31 Mar 2025 07:42:14 GMT
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
*
```

## On creating new playlist

```shell
❯ curl --location 'http://localhost:8080/playlists' \
      --header 'Authorization: Bearer <token>' \
      --header 'Content-Type: application/json' \
      --data '{"artists":[{"name": "Brutus"}],"playlist":{"name":"Brutus set","description
":"","isPublic":false}}' -v
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> POST /playlists HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> Authorization: Bearer <token>
> Content-Type: application/json
> Content-Length: 99
> 
* upload completely sent off: 99 bytes
< HTTP/1.1 201 Created
< Date: Mon, 31 Mar 2025 07:45:44 GMT
< Content-Length: 45
< Content-Type: text/plain; charset=utf-8
< 
{"playlist":{"id":"1ukgYa94pHPWcbqSofPxEI"}}
* Connection #0 to host localhost left intact
*
```